### PR TITLE
feat(server): add docker provider support

### DIFF
--- a/apps/beeai-cli/src/beeai_cli/commands/provider.py
+++ b/apps/beeai-cli/src/beeai_cli/commands/provider.py
@@ -55,7 +55,15 @@ async def list():
     ):
         table.add_row(
             item["id"],
-            render_enum(item["status"], {"ready": "green", "initializing": "yellow", "error": "red"}),
+            render_enum(
+                item["status"],
+                {
+                    "ready": "green",
+                    "initializing": "yellow",
+                    "error": "red",
+                    "unsupported": "orange1",
+                },
+            ),
             item["last_error"] if item["status"] != "ready" else "",
         )
     console.print(table)

--- a/apps/beeai-server/src/beeai_server/exceptions.py
+++ b/apps/beeai-server/src/beeai_server/exceptions.py
@@ -12,3 +12,6 @@ class ManifestLoadError(Exception):
 
 
 class LoadFeaturesError(Exception): ...
+
+
+class UnsupportedProviderError(FileNotFoundError): ...

--- a/apps/beeai-server/src/beeai_server/utils/utils.py
+++ b/apps/beeai-server/src/beeai_server/utils/utils.py
@@ -1,5 +1,8 @@
+import functools
+import shutil
 from typing import TypeVar, Iterable
 
+import anyio.to_thread
 
 T = TypeVar("T")
 V = TypeVar("V")
@@ -24,3 +27,12 @@ def extract_messages(exc):
         return [(exc_type, msg) for e in exc.exceptions for exc_type, msg in extract_messages(e)]
     else:
         return [(type(exc).__name__, str(exc))]
+
+
+@functools.cache
+def _which_sync(command: str):
+    return shutil.which(command)
+
+
+async def which(command: str):
+    return await anyio.to_thread.run_sync(_which_sync, command)


### PR DESCRIPTION
Ref: #58

Requires `host.docker.internal` to support local ollama, no way around it, `--network=host` does not help, it's only supported on linux.
- works in docker
- works in Rancher destkop
- no idea in podman

Example:
```
git clone https://github.com/jezekra1/test-manifest
docker build . -t test-manifest:local

mise beeai-cli:run provider add file:///path/to/test-manifest/beeai-provider.docker.yaml
```