### PR TITLE
feat: use `nwa` to manage copyright headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/agents/community/gpt-researcher-agent/pyproject.toml
+++ b/agents/community/gpt-researcher-agent/pyproject.toml
@@ -2,7 +2,7 @@
 name = "gpt-researcher-agent"
 version = "0.1.0"
 description = ""
-authors = [{ name = "Lukáš Janeček", email = "xjacka@gmail.com" }]
+authors = [{ name = "IBM Corp." }]
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 dependencies = [

--- a/agents/official/bee-agent-framework/package.json
+++ b/agents/official/bee-agent-framework/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "keywords": [],
-  "author": "",
+  "author": "IBM Corp.",
   "license": "MIT",
   "description": "",
   "dependencies": {

--- a/apps/beeai-cli/pyproject.toml
+++ b/apps/beeai-cli/pyproject.toml
@@ -3,9 +3,7 @@ name = "beeai-cli"
 version = "0.0.2"
 description = "Add your description here"
 readme = "README.md"
-authors = [
-    { name = "Radek Ježek", email = "radek.jezek@ibm.com" }
-]
+authors = [{ name = "IBM Corp." }]
 requires-python = ">=3.11,<4.0"
 dependencies = [
     "acp-sdk>=0.0.1",

--- a/apps/beeai-cli/src/beeai_cli/__init__.py
+++ b/apps/beeai-cli/src/beeai_cli/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from beeai_cli.async_typer import AsyncTyper
 import beeai_cli.commands.tool
 import beeai_cli.commands.agent

--- a/apps/beeai-cli/src/beeai_cli/api.py
+++ b/apps/beeai-cli/src/beeai_cli/api.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import urllib
 import urllib.parse
 import uuid

--- a/apps/beeai-cli/src/beeai_cli/async_typer.py
+++ b/apps/beeai-cli/src/beeai_cli/async_typer.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import typer
 import functools
 import inspect

--- a/apps/beeai-cli/src/beeai_cli/commands/__init__.py
+++ b/apps/beeai-cli/src/beeai_cli/commands/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/apps/beeai-cli/src/beeai_cli/commands/agent.py
+++ b/apps/beeai-cli/src/beeai_cli/commands/agent.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import sys
 

--- a/apps/beeai-cli/src/beeai_cli/commands/provider.py
+++ b/apps/beeai-cli/src/beeai_cli/commands/provider.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from enum import StrEnum
 from pathlib import Path
 

--- a/apps/beeai-cli/src/beeai_cli/commands/tool.py
+++ b/apps/beeai-cli/src/beeai_cli/commands/tool.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 
 import rich

--- a/apps/beeai-cli/src/beeai_cli/configuration.py
+++ b/apps/beeai-cli/src/beeai_cli/configuration.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import functools
 
 import pydantic

--- a/apps/beeai-cli/src/beeai_cli/utils.py
+++ b/apps/beeai-cli/src/beeai_cli/utils.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import yaml
 from pydantic import BaseModel
 

--- a/apps/beeai-server/pyproject.toml
+++ b/apps/beeai-server/pyproject.toml
@@ -3,7 +3,7 @@ name = "beeai-server"
 version = "0.0.1"
 description = "Add your description here"
 readme = "README.md"
-authors = [{ name = "Radek Ježek", email = "radek.jezek@ibm.com" }]
+authors = [{ name = "IBM Corp." }]
 requires-python = ">=3.11,<4.0"
 dependencies = [
     "acp-sdk>=0.0.1",

--- a/apps/beeai-server/src/beeai_server/__init__.py
+++ b/apps/beeai-server/src/beeai_server/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import os
 import socket

--- a/apps/beeai-server/src/beeai_server/adapters/__init__.py
+++ b/apps/beeai-server/src/beeai_server/adapters/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/apps/beeai-server/src/beeai_server/adapters/filesystem.py
+++ b/apps/beeai-server/src/beeai_server/adapters/filesystem.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 from pathlib import Path
 from typing import AsyncIterator

--- a/apps/beeai-server/src/beeai_server/adapters/interface.py
+++ b/apps/beeai-server/src/beeai_server/adapters/interface.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import runtime_checkable, Protocol, AsyncIterator
 
 from beeai_server.domain.model import Provider

--- a/apps/beeai-server/src/beeai_server/application.py
+++ b/apps/beeai-server/src/beeai_server/application.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import asyncio
 import contextlib
 import logging

--- a/apps/beeai-server/src/beeai_server/bootstrap.py
+++ b/apps/beeai-server/src/beeai_server/bootstrap.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from kink import di
 from acp.server.sse import SseServerTransport
 

--- a/apps/beeai-server/src/beeai_server/configuration.py
+++ b/apps/beeai-server/src/beeai_server/configuration.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 from functools import cache
 from pathlib import Path

--- a/apps/beeai-server/src/beeai_server/crons/__init__.py
+++ b/apps/beeai-server/src/beeai_server/crons/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/apps/beeai-server/src/beeai_server/crons/reload_provider_container.py
+++ b/apps/beeai-server/src/beeai_server/crons/reload_provider_container.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 from datetime import timedelta
 

--- a/apps/beeai-server/src/beeai_server/crons/sync_registry_providers.py
+++ b/apps/beeai-server/src/beeai_server/crons/sync_registry_providers.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 from datetime import timedelta
 

--- a/apps/beeai-server/src/beeai_server/custom_types.py
+++ b/apps/beeai-server/src/beeai_server/custom_types.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import AsyncGenerator, TypeAlias
 
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream

--- a/apps/beeai-server/src/beeai_server/domain/__init__.py
+++ b/apps/beeai-server/src/beeai_server/domain/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/apps/beeai-server/src/beeai_server/domain/constants.py
+++ b/apps/beeai-server/src/beeai_server/domain/constants.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Final
 
 DEFAULT_MANIFEST_PATH: Final = "beeai-provider.yaml"

--- a/apps/beeai-server/src/beeai_server/domain/model.py
+++ b/apps/beeai-server/src/beeai_server/domain/model.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import abc
 import uuid
 from contextlib import asynccontextmanager

--- a/apps/beeai-server/src/beeai_server/exceptions.py
+++ b/apps/beeai-server/src/beeai_server/exceptions.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from starlette.status import HTTP_404_NOT_FOUND
 
 

--- a/apps/beeai-server/src/beeai_server/logging_config.py
+++ b/apps/beeai-server/src/beeai_server/logging_config.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import contextlib
 import logging
 import logging.config

--- a/apps/beeai-server/src/beeai_server/routes/__init__.py
+++ b/apps/beeai-server/src/beeai_server/routes/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/apps/beeai-server/src/beeai_server/routes/dependencies.py
+++ b/apps/beeai-server/src/beeai_server/routes/dependencies.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Annotated
 
 from beeai_server.services.mcp_proxy.proxy_server import MCPProxyServer

--- a/apps/beeai-server/src/beeai_server/routes/mcp_sse.py
+++ b/apps/beeai-server/src/beeai_server/routes/mcp_sse.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 from asyncio import CancelledError
 

--- a/apps/beeai-server/src/beeai_server/routes/provider.py
+++ b/apps/beeai-server/src/beeai_server/routes/provider.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import fastapi
 
 from beeai_server.routes.dependencies import ProviderServiceDependency

--- a/apps/beeai-server/src/beeai_server/schema.py
+++ b/apps/beeai-server/src/beeai_server/schema.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import TypeVar, Generic
 from pydantic import BaseModel
 

--- a/apps/beeai-server/src/beeai_server/services/__init__.py
+++ b/apps/beeai-server/src/beeai_server/services/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/apps/beeai-server/src/beeai_server/services/mcp_proxy/__init__.py
+++ b/apps/beeai-server/src/beeai_server/services/mcp_proxy/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/apps/beeai-server/src/beeai_server/services/mcp_proxy/constants.py
+++ b/apps/beeai-server/src/beeai_server/services/mcp_proxy/constants.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from enum import StrEnum
 
 

--- a/apps/beeai-server/src/beeai_server/services/mcp_proxy/notification_hub.py
+++ b/apps/beeai-server/src/beeai_server/services/mcp_proxy/notification_hub.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 from asyncio import CancelledError
 from collections import defaultdict

--- a/apps/beeai-server/src/beeai_server/services/mcp_proxy/provider.py
+++ b/apps/beeai-server/src/beeai_server/services/mcp_proxy/provider.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import asyncio
 import logging
 from contextlib import AsyncExitStack

--- a/apps/beeai-server/src/beeai_server/services/mcp_proxy/proxy_server.py
+++ b/apps/beeai-server/src/beeai_server/services/mcp_proxy/proxy_server.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import uuid
 from contextlib import asynccontextmanager

--- a/apps/beeai-server/src/beeai_server/services/provider.py
+++ b/apps/beeai-server/src/beeai_server/services/provider.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from kink import inject
 from starlette.status import HTTP_400_BAD_REQUEST
 

--- a/apps/beeai-server/src/beeai_server/utils/__init__.py
+++ b/apps/beeai-server/src/beeai_server/utils/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/apps/beeai-server/src/beeai_server/utils/github.py
+++ b/apps/beeai-server/src/beeai_server/utils/github.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import pathlib
 import re

--- a/apps/beeai-server/src/beeai_server/utils/managed_server_client.py
+++ b/apps/beeai-server/src/beeai_server/utils/managed_server_client.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import asyncio
 import logging
 import os

--- a/apps/beeai-server/src/beeai_server/utils/periodic.py
+++ b/apps/beeai-server/src/beeai_server/utils/periodic.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import asyncio

--- a/apps/beeai-server/src/beeai_server/utils/utils.py
+++ b/apps/beeai-server/src/beeai_server/utils/utils.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import functools
 import shutil
 from typing import TypeVar, Iterable

--- a/apps/beeai-ui/package.json
+++ b/apps/beeai-ui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@beeai/ui",
+  "autor": "IBM Corp.",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/apps/beeai-ui/src/@types/carbon__motion/index.d.ts
+++ b/apps/beeai-ui/src/@types/carbon__motion/index.d.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 declare module '@carbon/motion' {
   export const fast01: string;
   export const fast02: string;

--- a/apps/beeai-ui/src/@types/svg.d.ts
+++ b/apps/beeai-ui/src/@types/svg.d.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 declare module '*.svg' {
   import * as React from 'react';
 

--- a/apps/beeai-ui/src/App.tsx
+++ b/apps/beeai-ui/src/App.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ErrorBoundary } from 'react-error-boundary';
 import { BrowserRouter, Route, Routes } from 'react-router';

--- a/apps/beeai-ui/src/api/index.ts
+++ b/apps/beeai-ui/src/api/index.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import ky from 'ky';
 
 export const api = ky.create({ prefixUrl: '/api/v1/' });

--- a/apps/beeai-ui/src/api/mcp-client/useCreateMCPClient.ts
+++ b/apps/beeai-ui/src/api/mcp-client/useCreateMCPClient.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Client as MCPClient } from '@i-am-bee/acp-sdk/client/index.js';
 import { SSEClientTransport } from '@i-am-bee/acp-sdk/client/sse.js';
 import { useCallback, useEffect, useRef } from 'react';

--- a/apps/beeai-ui/src/components/CommunityNav/CommunityNav.module.scss
+++ b/apps/beeai-ui/src/components/CommunityNav/CommunityNav.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .list {
   display: flex;
   gap: $spacing-04;

--- a/apps/beeai-ui/src/components/CommunityNav/CommunityNav.tsx
+++ b/apps/beeai-ui/src/components/CommunityNav/CommunityNav.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import LogoBluesky from '@/svgs/LogoBluesky.svg';
 import { BLUESKY_LINK, DISCORD_LINK, GITHUB_REPO_LINK, YOUTUBE_LINK } from '@/utils/constants';
 import { LogoDiscord, LogoGithub, LogoYoutube } from '@carbon/icons-react';

--- a/apps/beeai-ui/src/components/ConfirmDialog/ConfirmDialog.module.scss
+++ b/apps/beeai-ui/src/components/ConfirmDialog/ConfirmDialog.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .heading {
   font-size: rem(24px);
   line-height: math.div(28, 24);

--- a/apps/beeai-ui/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/apps/beeai-ui/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
 import { TrashCan } from '@carbon/react/icons';
 import clsx from 'clsx';

--- a/apps/beeai-ui/src/components/CopySnippet/CopySnippet.module.scss
+++ b/apps/beeai-ui/src/components/CopySnippet/CopySnippet.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   position: relative;
   display: flex;

--- a/apps/beeai-ui/src/components/CopySnippet/CopySnippet.tsx
+++ b/apps/beeai-ui/src/components/CopySnippet/CopySnippet.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Checkmark, Copy } from '@carbon/icons-react';
 import { IconButton } from '@carbon/react';
 import clsx from 'clsx';

--- a/apps/beeai-ui/src/components/ErrorMessage/ErrorMessage.module.scss
+++ b/apps/beeai-ui/src/components/ErrorMessage/ErrorMessage.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   inline-size: 100%;
   max-inline-size: none;

--- a/apps/beeai-ui/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/apps/beeai-ui/src/components/ErrorMessage/ErrorMessage.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ActionableNotification, Button, InlineLoading } from '@carbon/react';
 import { ReactNode } from 'react';
 import classes from './ErrorMessage.module.scss';

--- a/apps/beeai-ui/src/components/ErrorPage/ErrorPage.module.scss
+++ b/apps/beeai-ui/src/components/ErrorPage/ErrorPage.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   min-block-size: 100%;
   display: flex;

--- a/apps/beeai-ui/src/components/ErrorPage/ErrorPage.tsx
+++ b/apps/beeai-ui/src/components/ErrorPage/ErrorPage.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import NotFound from '@/svgs/NotFound.svg';
 import { routes } from '@/utils/router';
 import { ArrowRight } from '@carbon/icons-react';

--- a/apps/beeai-ui/src/components/MainNav/MainNav.module.scss
+++ b/apps/beeai-ui/src/components/MainNav/MainNav.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .list {
   display: flex;
   column-gap: $spacing-07;

--- a/apps/beeai-ui/src/components/MainNav/MainNav.tsx
+++ b/apps/beeai-ui/src/components/MainNav/MainNav.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { routes } from '@/utils/router';
 import { NavLink } from 'react-router';
 import classes from './MainNav.module.scss';

--- a/apps/beeai-ui/src/components/MarkdownContent/MarkdownContent.module.scss
+++ b/apps/beeai-ui/src/components/MarkdownContent/MarkdownContent.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   @include type-style(body-01);
 

--- a/apps/beeai-ui/src/components/MarkdownContent/MarkdownContent.tsx
+++ b/apps/beeai-ui/src/components/MarkdownContent/MarkdownContent.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import clsx from 'clsx';
 import Markdown from 'react-markdown';
 import { PluggableList } from 'unified';

--- a/apps/beeai-ui/src/components/MarkdownContent/plugins/rehypeCarbonLists.ts
+++ b/apps/beeai-ui/src/components/MarkdownContent/plugins/rehypeCarbonLists.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Root } from 'hast';
 import { visit } from 'unist-util-visit';
 

--- a/apps/beeai-ui/src/components/Modal/Modal.module.scss
+++ b/apps/beeai-ui/src/components/Modal/Modal.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   position: relative;
   z-index: z('modal');

--- a/apps/beeai-ui/src/components/Modal/Modal.tsx
+++ b/apps/beeai-ui/src/components/Modal/Modal.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { moderate02 } from '@carbon/motion';
 import { ComposedModal } from '@carbon/react';
 import clsx from 'clsx';

--- a/apps/beeai-ui/src/components/SideNav/SideNav.module.scss
+++ b/apps/beeai-ui/src/components/SideNav/SideNav.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .list {
   display: flex;
   column-gap: $spacing-06;

--- a/apps/beeai-ui/src/components/SideNav/SideNav.tsx
+++ b/apps/beeai-ui/src/components/SideNav/SideNav.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { DOCUMENTATION_LINK } from '@/utils/constants';
 import classes from './SideNav.module.scss';
 

--- a/apps/beeai-ui/src/components/Spinner/Spinner.module.scss
+++ b/apps/beeai-ui/src/components/Spinner/Spinner.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   block-size: 1rem;
   inline-size: 1.5rem;

--- a/apps/beeai-ui/src/components/Spinner/Spinner.tsx
+++ b/apps/beeai-ui/src/components/Spinner/Spinner.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import Lottie from 'lottie-react';
 import SpinnerAnimation from './BouncingDotsAnimation.json';
 import classes from './Spinner.module.scss';

--- a/apps/beeai-ui/src/components/TagsList/TagsList.module.scss
+++ b/apps/beeai-ui/src/components/TagsList/TagsList.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   display: flex;
   flex-wrap: wrap;

--- a/apps/beeai-ui/src/components/TagsList/TagsList.tsx
+++ b/apps/beeai-ui/src/components/TagsList/TagsList.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { TagSkeleton } from '@carbon/react';
 import clsx from 'clsx';
 import { ReactElement } from 'react';

--- a/apps/beeai-ui/src/components/TextAreaAutoHeight/TextAreaAutoHeight.module.scss
+++ b/apps/beeai-ui/src/components/TextAreaAutoHeight/TextAreaAutoHeight.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 $line-size: math.div(21, 14) * 0.875rem;
 
 .root {

--- a/apps/beeai-ui/src/components/TextAreaAutoHeight/TextAreaAutoHeight.tsx
+++ b/apps/beeai-ui/src/components/TextAreaAutoHeight/TextAreaAutoHeight.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import clsx from 'clsx';
 import {
   CSSProperties,

--- a/apps/beeai-ui/src/components/ToTopButton/ToTopButton.module.scss
+++ b/apps/beeai-ui/src/components/ToTopButton/ToTopButton.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   position: fixed;
   inset-block-end: $grid-margin;

--- a/apps/beeai-ui/src/components/ToTopButton/ToTopButton.tsx
+++ b/apps/beeai-ui/src/components/ToTopButton/ToTopButton.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ArrowUp } from '@carbon/icons-react';
 import { IconButton, IconButtonProps } from '@carbon/react';
 import classes from './ToTopButton.module.scss';

--- a/apps/beeai-ui/src/components/ViewHeader/ViewHeader.module.scss
+++ b/apps/beeai-ui/src/components/ViewHeader/ViewHeader.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   display: flex;
   flex-direction: column;

--- a/apps/beeai-ui/src/components/ViewHeader/ViewHeader.tsx
+++ b/apps/beeai-ui/src/components/ViewHeader/ViewHeader.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { PropsWithChildren, ReactElement } from 'react';
 import classes from './ViewHeader.module.scss';
 

--- a/apps/beeai-ui/src/components/ViewStack/ViewStack.module.scss
+++ b/apps/beeai-ui/src/components/ViewStack/ViewStack.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   display: flex;
   flex-direction: column;

--- a/apps/beeai-ui/src/components/ViewStack/ViewStack.tsx
+++ b/apps/beeai-ui/src/components/ViewStack/ViewStack.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { PropsWithChildren } from 'react';
 import classes from './ViewStack.module.scss';
 

--- a/apps/beeai-ui/src/components/fallbacks/ErrorFallback.tsx
+++ b/apps/beeai-ui/src/components/fallbacks/ErrorFallback.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { FallbackProps } from 'react-error-boundary';
 import { ErrorLayout } from '../layouts/ErrorLayout';
 

--- a/apps/beeai-ui/src/components/fallbacks/ModalFallback.tsx
+++ b/apps/beeai-ui/src/components/fallbacks/ModalFallback.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
 import type { FallbackProps } from 'react-error-boundary';
 import { Modal } from '../Modal/Modal';

--- a/apps/beeai-ui/src/components/layouts/AppFooter.module.scss
+++ b/apps/beeai-ui/src/components/layouts/AppFooter.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .holder {
   display: flex;
   column-gap: $gap;

--- a/apps/beeai-ui/src/components/layouts/AppFooter.tsx
+++ b/apps/beeai-ui/src/components/layouts/AppFooter.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { CommunityNav } from '../CommunityNav/CommunityNav';
 import classes from './AppFooter.module.scss';
 import { Container } from './Container';

--- a/apps/beeai-ui/src/components/layouts/AppHeader.module.scss
+++ b/apps/beeai-ui/src/components/layouts/AppHeader.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   position: sticky;
   inset-block-start: 0;

--- a/apps/beeai-ui/src/components/layouts/AppHeader.tsx
+++ b/apps/beeai-ui/src/components/layouts/AppHeader.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import clsx from 'clsx';
 import { CommunityNav } from '../CommunityNav/CommunityNav';
 import { MainNav } from '../MainNav/MainNav';

--- a/apps/beeai-ui/src/components/layouts/AppLayout.module.scss
+++ b/apps/beeai-ui/src/components/layouts/AppLayout.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   display: grid;
   block-size: 100dvh;

--- a/apps/beeai-ui/src/components/layouts/AppLayout.tsx
+++ b/apps/beeai-ui/src/components/layouts/AppLayout.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { routes } from '@/utils/router';
 import { UIEventHandler, useCallback, useRef, useState } from 'react';
 import { Outlet, useLocation } from 'react-router';

--- a/apps/beeai-ui/src/components/layouts/Container.module.scss
+++ b/apps/beeai-ui/src/components/layouts/Container.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @use 'sass:map';
 
 .root {

--- a/apps/beeai-ui/src/components/layouts/Container.tsx
+++ b/apps/beeai-ui/src/components/layouts/Container.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import clsx from 'clsx';
 import { PropsWithChildren } from 'react';
 import classes from './Container.module.scss';

--- a/apps/beeai-ui/src/components/layouts/ErrorLayout.module.scss
+++ b/apps/beeai-ui/src/components/layouts/ErrorLayout.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   display: grid;
   align-items: center;

--- a/apps/beeai-ui/src/components/layouts/ErrorLayout.tsx
+++ b/apps/beeai-ui/src/components/layouts/ErrorLayout.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { PropsWithChildren } from 'react';
 import { Container } from './Container';
 import classes from './ErrorLayout.module.scss';

--- a/apps/beeai-ui/src/contexts/MCPClient/MCPClientProvider.tsx
+++ b/apps/beeai-ui/src/contexts/MCPClient/MCPClientProvider.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { PropsWithChildren, useEffect, useState } from 'react';
 import { MCPClientContext } from './mcp-client-context';
 import { useCreateMCPClient } from '@/api/mcp-client/useCreateMCPClient';

--- a/apps/beeai-ui/src/contexts/MCPClient/index.ts
+++ b/apps/beeai-ui/src/contexts/MCPClient/index.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { use } from 'react';
 import { MCPClientContext } from './mcp-client-context';
 

--- a/apps/beeai-ui/src/contexts/MCPClient/mcp-client-context.ts
+++ b/apps/beeai-ui/src/contexts/MCPClient/mcp-client-context.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Client as MCPClient } from '@i-am-bee/acp-sdk/client/index.js';
 import { createContext } from 'react';
 

--- a/apps/beeai-ui/src/contexts/Modal/ModalProvider.tsx
+++ b/apps/beeai-ui/src/contexts/Modal/ModalProvider.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { memo, PropsWithChildren, useCallback, useLayoutEffect, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { v4 as uuid } from 'uuid';

--- a/apps/beeai-ui/src/contexts/Modal/index.tsx
+++ b/apps/beeai-ui/src/contexts/Modal/index.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useCallback, useContext } from 'react';
 import { ModalContext } from './modal-context';
 import { ConfirmDialogProps, ConfirmDialog } from '@/components/ConfirmDialog/ConfirmDialog';

--- a/apps/beeai-ui/src/contexts/Modal/modal-context.ts
+++ b/apps/beeai-ui/src/contexts/Modal/modal-context.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { noop } from '@/utils/helpers';
 import { createContext, ReactNode } from 'react';
 

--- a/apps/beeai-ui/src/contexts/Toast/ToastProvider.module.scss
+++ b/apps/beeai-ui/src/contexts/Toast/ToastProvider.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .toasts {
   position: fixed;
   inset-block-start: 0;

--- a/apps/beeai-ui/src/contexts/Toast/ToastProvider.tsx
+++ b/apps/beeai-ui/src/contexts/Toast/ToastProvider.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ToastNotification, usePrefix } from '@carbon/react';
 import { PropsWithChildren, useCallback, useMemo, useState } from 'react';
 import { v4 as uuid } from 'uuid';

--- a/apps/beeai-ui/src/contexts/Toast/index.ts
+++ b/apps/beeai-ui/src/contexts/Toast/index.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { use } from 'react';
 import { ToastContext } from './toast-context';
 

--- a/apps/beeai-ui/src/contexts/Toast/toast-context.ts
+++ b/apps/beeai-ui/src/contexts/Toast/toast-context.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createContext, ReactNode } from 'react';
 
 export interface Toast {

--- a/apps/beeai-ui/src/hooks/useImmerWithGetter.ts
+++ b/apps/beeai-ui/src/hooks/useImmerWithGetter.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useMemo, useRef, useState } from 'react';
 import { Draft, produce } from 'immer';
 

--- a/apps/beeai-ui/src/main.tsx
+++ b/apps/beeai-ui/src/main.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';

--- a/apps/beeai-ui/src/modules/agents/api/index.ts
+++ b/apps/beeai-ui/src/modules/agents/api/index.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { api } from '@/api';
 import { CreateProviderBody } from './types';
 

--- a/apps/beeai-ui/src/modules/agents/api/keys.ts
+++ b/apps/beeai-ui/src/modules/agents/api/keys.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ListAgentsParams } from './types';
 
 export const agentKeys = {

--- a/apps/beeai-ui/src/modules/agents/api/mutations/useImportAgents.ts
+++ b/apps/beeai-ui/src/modules/agents/api/mutations/useImportAgents.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createProvider } from '..';
 import { agentKeys } from '../keys';

--- a/apps/beeai-ui/src/modules/agents/api/queries/useAgent.ts
+++ b/apps/beeai-ui/src/modules/agents/api/queries/useAgent.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useMCPClient } from '@/contexts/MCPClient';
 import { useQuery } from '@tanstack/react-query';
 import { agentKeys } from '../keys';

--- a/apps/beeai-ui/src/modules/agents/api/queries/useListAgents.ts
+++ b/apps/beeai-ui/src/modules/agents/api/queries/useListAgents.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useMCPClient } from '@/contexts/MCPClient';
 import { useQuery } from '@tanstack/react-query';
 import { agentKeys } from '../keys';

--- a/apps/beeai-ui/src/modules/agents/api/types.ts
+++ b/apps/beeai-ui/src/modules/agents/api/types.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ListAgentsRequest, Agent as SdkAgent } from '@i-am-bee/acp-sdk/types.js';
 import { Metadata } from '@i-am-bee/beeai-sdk/schemas/metadata';
 

--- a/apps/beeai-ui/src/modules/agents/components/AgentCard.module.scss
+++ b/apps/beeai-ui/src/modules/agents/components/AgentCard.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   border-block-end: 1px solid $border-subtle;
   padding-block: $spacing-06;

--- a/apps/beeai-ui/src/modules/agents/components/AgentCard.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentCard.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { MarkdownContent } from '@/components/MarkdownContent/MarkdownContent';
 import { TagsList } from '@/components/TagsList/TagsList';
 import { routes } from '@/utils/router';

--- a/apps/beeai-ui/src/modules/agents/components/AgentMetadata.module.scss
+++ b/apps/beeai-ui/src/modules/agents/components/AgentMetadata.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   @include type-style(label-01);
   color: $text-secondary;

--- a/apps/beeai-ui/src/modules/agents/components/AgentMetadata.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentMetadata.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Time } from '@carbon/icons-react';
 import { SkeletonText } from '@carbon/react';
 import clsx from 'clsx';

--- a/apps/beeai-ui/src/modules/agents/components/AgentModal.module.scss
+++ b/apps/beeai-ui/src/modules/agents/components/AgentModal.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .body {
   display: flex;
   flex-direction: column;

--- a/apps/beeai-ui/src/modules/agents/components/AgentModal.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentModal.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { CopySnippet } from '@/components/CopySnippet/CopySnippet';
 import { Modal } from '@/components/Modal/Modal';
 import { ModalProps } from '@/contexts/Modal/modal-context';

--- a/apps/beeai-ui/src/modules/agents/components/AgentTags.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentTags.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { TagsList } from '@/components/TagsList/TagsList';
 import Bee from '@/svgs/Bee.svg';
 import { isNotNull } from '@/utils/helpers';

--- a/apps/beeai-ui/src/modules/agents/components/AgentsFilters.module.scss
+++ b/apps/beeai-ui/src/modules/agents/components/AgentsFilters.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   display: flex;
   flex-direction: column;

--- a/apps/beeai-ui/src/modules/agents/components/AgentsFilters.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentsFilters.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { isNotNull } from '@/utils/helpers';
 import { Search } from '@carbon/icons-react';
 import { OperationalTag, TextInput } from '@carbon/react';

--- a/apps/beeai-ui/src/modules/agents/components/AgentsList.module.scss
+++ b/apps/beeai-ui/src/modules/agents/components/AgentsList.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .header {
   display: flex;
   justify-content: flex-end;

--- a/apps/beeai-ui/src/modules/agents/components/AgentsList.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentsList.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ErrorMessage } from '@/components/ErrorMessage/ErrorMessage';
 import { useModal } from '@/contexts/Modal';
 import { ImportAgentsModal } from '@/modules/agents/components/ImportAgentsModal';

--- a/apps/beeai-ui/src/modules/agents/components/ImportAgentsModal.module.scss
+++ b/apps/beeai-ui/src/modules/agents/components/ImportAgentsModal.module.scss
@@ -1,2 +1,18 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
 }

--- a/apps/beeai-ui/src/modules/agents/components/ImportAgentsModal.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/ImportAgentsModal.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Button, InlineLoading, ModalBody, ModalFooter, ModalHeader, TextInput } from '@carbon/react';
 import { ModalProps } from '@/contexts/Modal/modal-context';
 import { Modal } from '@/components/Modal/Modal';

--- a/apps/beeai-ui/src/modules/agents/components/SearchBar.module.scss
+++ b/apps/beeai-ui/src/modules/agents/components/SearchBar.module.scss
@@ -1,2 +1,18 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
 }

--- a/apps/beeai-ui/src/modules/agents/components/SearchBar.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/SearchBar.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Search } from '@carbon/react';
 import { useId } from 'react';
 import classes from './SearchBar.module.scss';

--- a/apps/beeai-ui/src/modules/agents/contexts/AgentsProvider.tsx
+++ b/apps/beeai-ui/src/modules/agents/contexts/AgentsProvider.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { PropsWithChildren } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useListAgents } from '../api/queries/useListAgents';

--- a/apps/beeai-ui/src/modules/agents/contexts/agents-context.tsx
+++ b/apps/beeai-ui/src/modules/agents/contexts/agents-context.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { createContext } from 'react';
 import { useListAgents } from '../api/queries/useListAgents';
 

--- a/apps/beeai-ui/src/modules/agents/contexts/index.tsx
+++ b/apps/beeai-ui/src/modules/agents/contexts/index.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useContext } from 'react';
 import { AgentsContext } from './agents-context';
 

--- a/apps/beeai-ui/src/modules/agents/detail/AgentDetail.module.scss
+++ b/apps/beeai-ui/src/modules/agents/detail/AgentDetail.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   padding-block-start: $spacing-05;
 

--- a/apps/beeai-ui/src/modules/agents/detail/AgentDetail.tsx
+++ b/apps/beeai-ui/src/modules/agents/detail/AgentDetail.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { CopySnippet } from '@/components/CopySnippet/CopySnippet';
 import { ErrorMessage } from '@/components/ErrorMessage/ErrorMessage';
 import { Container } from '@/components/layouts/Container';

--- a/apps/beeai-ui/src/modules/agents/hooks/useFilteredAgents.ts
+++ b/apps/beeai-ui/src/modules/agents/hooks/useFilteredAgents.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useMemo } from 'react';
 import { Agent } from '../api/types';
 import { AgentsFiltersParams } from '../contexts/agents-context';

--- a/apps/beeai-ui/src/modules/agents/utils.ts
+++ b/apps/beeai-ui/src/modules/agents/utils.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Agent } from './api/types';
 
 export function getAgentTitle(agent: Agent) {

--- a/apps/beeai-ui/src/modules/home/api/index.ts
+++ b/apps/beeai-ui/src/modules/home/api/index.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { GitHubRepoParams, GitHubRepoSchema } from './types';
 
 export async function fetchGitHubRepo({ owner, repo }: GitHubRepoParams) {

--- a/apps/beeai-ui/src/modules/home/api/key.ts
+++ b/apps/beeai-ui/src/modules/home/api/key.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { GitHubRepoParams } from './types';
 
 export const gitHubRepoKeys = {

--- a/apps/beeai-ui/src/modules/home/api/queries/useGitHubRepo.ts
+++ b/apps/beeai-ui/src/modules/home/api/queries/useGitHubRepo.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useQuery } from '@tanstack/react-query';
 import { fetchGitHubRepo } from '..';
 import { gitHubRepoKeys } from '../key';

--- a/apps/beeai-ui/src/modules/home/api/types.ts
+++ b/apps/beeai-ui/src/modules/home/api/types.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { z } from 'zod';
 export interface GitHubRepoParams {
   owner: string;

--- a/apps/beeai-ui/src/modules/home/components/GettingStarted.module.scss
+++ b/apps/beeai-ui/src/modules/home/components/GettingStarted.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   min-block-size: 100%;
   display: flex;

--- a/apps/beeai-ui/src/modules/home/components/GettingStarted.tsx
+++ b/apps/beeai-ui/src/modules/home/components/GettingStarted.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Container } from '@/components/layouts/Container';
 import LogoBeeAI from '@/svgs/LogoBeeAI.svg';
 import { GET_STARTED_PYTHON_LINK, GET_STARTED_TYPESCRIPT_LINK } from '@/utils/constants';

--- a/apps/beeai-ui/src/modules/home/components/GitHubStarsButton.module.scss
+++ b/apps/beeai-ui/src/modules/home/components/GitHubStarsButton.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   &:global(.cds--btn) {
     @include type-style(label-01);

--- a/apps/beeai-ui/src/modules/home/components/GitHubStarsButton.tsx
+++ b/apps/beeai-ui/src/modules/home/components/GitHubStarsButton.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Spinner } from '@/components/Spinner/Spinner';
 import { GITHUB_REPO } from '@/utils/constants';
 import { LogoGithub } from '@carbon/icons-react';

--- a/apps/beeai-ui/src/modules/home/components/InstallInstructions.module.scss
+++ b/apps/beeai-ui/src/modules/home/components/InstallInstructions.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @use '@carbon/styles/scss/utilities/button-reset';
 
 .root {

--- a/apps/beeai-ui/src/modules/home/components/InstallInstructions.tsx
+++ b/apps/beeai-ui/src/modules/home/components/InstallInstructions.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { CopySnippet } from '@/components/CopySnippet/CopySnippet';
 import { useCallback, useMemo, useState } from 'react';
 import classes from './InstallInstructions.module.scss';

--- a/apps/beeai-ui/src/modules/run/AgentRun.module.scss
+++ b/apps/beeai-ui/src/modules/run/AgentRun.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .container {
   block-size: 100%;
   max-block-size: 100%;

--- a/apps/beeai-ui/src/modules/run/AgentRun.tsx
+++ b/apps/beeai-ui/src/modules/run/AgentRun.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ErrorMessage } from '@/components/ErrorMessage/ErrorMessage';
 import { Container } from '@/components/layouts/Container';
 import { Loading } from '@carbon/react';

--- a/apps/beeai-ui/src/modules/run/api/mutations/useRunAgent.tsx
+++ b/apps/beeai-ui/src/modules/run/api/mutations/useRunAgent.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useMutation } from '@tanstack/react-query';
 import { Agent } from '@i-am-bee/acp-sdk/types.js';
 import z, { ZodLiteral, ZodObject } from 'zod';

--- a/apps/beeai-ui/src/modules/run/chat/AgentIcon.module.scss
+++ b/apps/beeai-ui/src/modules/run/chat/AgentIcon.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   block-size: rem(32px);
   inline-size: rem(32px);

--- a/apps/beeai-ui/src/modules/run/chat/AgentIcon.tsx
+++ b/apps/beeai-ui/src/modules/run/chat/AgentIcon.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import Bee from '@/svgs/Bee.svg';
 import classes from './AgentIcon.module.scss';
 

--- a/apps/beeai-ui/src/modules/run/chat/Chat.module.scss
+++ b/apps/beeai-ui/src/modules/run/chat/Chat.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   block-size: 100%;
   display: flex;

--- a/apps/beeai-ui/src/modules/run/chat/Chat.tsx
+++ b/apps/beeai-ui/src/modules/run/chat/Chat.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Container } from '@/components/layouts/Container';
 import { getAgentTitle } from '@/modules/agents/utils';
 import { ArrowDown } from '@carbon/icons-react';

--- a/apps/beeai-ui/src/modules/run/chat/InputBar.module.scss
+++ b/apps/beeai-ui/src/modules/run/chat/InputBar.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @use '@carbon/styles/scss/utilities/visually-hidden' as *;
 
 .root {

--- a/apps/beeai-ui/src/modules/run/chat/InputBar.tsx
+++ b/apps/beeai-ui/src/modules/run/chat/InputBar.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { TextAreaAutoHeight } from '@/components/TextAreaAutoHeight/TextAreaAutoHeight';
 import { dispatchInputEventOnFormTextarea, submitFormOnEnter } from '@/utils/formUtils';
 import { Send, StopOutlineFilled } from '@carbon/icons-react';

--- a/apps/beeai-ui/src/modules/run/chat/Message.module.scss
+++ b/apps/beeai-ui/src/modules/run/chat/Message.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 $avatar-padding-left: $spacing-04 + rem(32px);
 
 .root {

--- a/apps/beeai-ui/src/modules/run/chat/Message.tsx
+++ b/apps/beeai-ui/src/modules/run/chat/Message.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ErrorMessage } from '@/components/ErrorMessage/ErrorMessage';
 import { Spinner } from '@/components/Spinner/Spinner';
 import { getAgentTitle } from '@/modules/agents/utils';

--- a/apps/beeai-ui/src/modules/run/chat/UserIcon.module.scss
+++ b/apps/beeai-ui/src/modules/run/chat/UserIcon.module.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .root {
   block-size: rem(32px);
   inline-size: rem(32px);

--- a/apps/beeai-ui/src/modules/run/chat/UserIcon.tsx
+++ b/apps/beeai-ui/src/modules/run/chat/UserIcon.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import classes from './UserIcon.module.scss';
 import { User } from '@carbon/icons-react';
 

--- a/apps/beeai-ui/src/modules/run/chat/types.ts
+++ b/apps/beeai-ui/src/modules/run/chat/types.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { AgentRunProgressNotificationSchema, RunAgentResultSchema } from '@i-am-bee/acp-sdk/types.js';
 import { messageOutputSchema } from '@i-am-bee/beeai-sdk/schemas/message';
 import { z } from 'zod';

--- a/apps/beeai-ui/src/modules/run/contexts/ChatProvider.tsx
+++ b/apps/beeai-ui/src/modules/run/contexts/ChatProvider.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useImmerWithGetter } from '@/hooks/useImmerWithGetter';
 import { Agent } from '@/modules/agents/api/types';
 import { MessageInput } from '@i-am-bee/beeai-sdk/schemas/message';

--- a/apps/beeai-ui/src/modules/run/contexts/chat-context.ts
+++ b/apps/beeai-ui/src/modules/run/contexts/chat-context.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Updater } from '@/hooks/useImmerWithGetter';
 import { Agent } from '@/modules/agents/api/types';
 import { createContext } from 'react';

--- a/apps/beeai-ui/src/modules/run/contexts/index.ts
+++ b/apps/beeai-ui/src/modules/run/contexts/index.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { use } from 'react';
 import { ChatContext, ChatMessagesContext } from './chat-context';
 

--- a/apps/beeai-ui/src/modules/tools/api/keys.ts
+++ b/apps/beeai-ui/src/modules/tools/api/keys.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ListToolsParams } from './types';
 
 export const toolKeys = {

--- a/apps/beeai-ui/src/modules/tools/api/queries/useListTools.ts
+++ b/apps/beeai-ui/src/modules/tools/api/queries/useListTools.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useMCPClient } from '@/contexts/MCPClient';
 import { useQuery } from '@tanstack/react-query';
 import { toolKeys } from '../keys';

--- a/apps/beeai-ui/src/modules/tools/api/types.ts
+++ b/apps/beeai-ui/src/modules/tools/api/types.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ListToolsRequest } from '@i-am-bee/acp-sdk/types.js';
 
 export type ListToolsParams = ListToolsRequest['params'];

--- a/apps/beeai-ui/src/modules/tools/components/ToolsView.tsx
+++ b/apps/beeai-ui/src/modules/tools/components/ToolsView.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { useListTools } from '../api/queries/useListTools';
 
 export const ToolsView = () => {

--- a/apps/beeai-ui/src/pages/Agents.tsx
+++ b/apps/beeai-ui/src/pages/Agents.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Container } from '@/components/layouts/Container';
 import { ViewStack } from '@/components/ViewStack/ViewStack';
 import { AgentsFilters } from '@/modules/agents/components/AgentsFilters';

--- a/apps/beeai-ui/src/pages/Home.tsx
+++ b/apps/beeai-ui/src/pages/Home.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { GettingStarted } from '@/modules/home/components/GettingStarted';
 
 export function Home() {

--- a/apps/beeai-ui/src/pages/NotFound.tsx
+++ b/apps/beeai-ui/src/pages/NotFound.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { ErrorPage } from '@/components/ErrorPage/ErrorPage';
 
 export function NotFound() {

--- a/apps/beeai-ui/src/pages/agents/Agent.tsx
+++ b/apps/beeai-ui/src/pages/agents/Agent.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { AgentDetail } from '@/modules/agents/detail/AgentDetail';
 import { routes } from '@/utils/router';
 import { useNavigate, useParams } from 'react-router';

--- a/apps/beeai-ui/src/pages/run/AgentRunPage.tsx
+++ b/apps/beeai-ui/src/pages/run/AgentRunPage.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { AgentRun } from '@/modules/run/AgentRun';
 import { routes } from '@/utils/router';
 import { useNavigate, useParams } from 'react-router';

--- a/apps/beeai-ui/src/styles/_common.scss
+++ b/apps/beeai-ui/src/styles/_common.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @forward '@carbon/styles/scss/config' with (
   $font-display: swap
 );

--- a/apps/beeai-ui/src/styles/_functions.scss
+++ b/apps/beeai-ui/src/styles/_functions.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @use 'sass:map';
 @use 'sass:string';
 @use 'sass:list';

--- a/apps/beeai-ui/src/styles/_grid.scss
+++ b/apps/beeai-ui/src/styles/_grid.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @use 'sass:map';
 
 @use '@carbon/grid/scss/config' as *;

--- a/apps/beeai-ui/src/styles/_mixins.scss
+++ b/apps/beeai-ui/src/styles/_mixins.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @use '@carbon/styles/scss/theme' as *;
 @use '@carbon/styles/scss/spacing' as *;
 

--- a/apps/beeai-ui/src/styles/_theme.scss
+++ b/apps/beeai-ui/src/styles/_theme.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @use 'sass:map';
 @use '@carbon/styles/scss/themes';
 @use '@carbon/styles/scss/theme' as *;

--- a/apps/beeai-ui/src/styles/components/_button.scss
+++ b/apps/beeai-ui/src/styles/components/_button.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @use 'styles/common' as *;
 
 .cds--btn {

--- a/apps/beeai-ui/src/styles/components/_index.scss
+++ b/apps/beeai-ui/src/styles/components/_index.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // @forward '@carbon/styles/scss/components/accordion';
 // @forward '@carbon/styles/scss/components/ai-label';
 // @forward '@carbon/styles/scss/components/aspect-ratio';

--- a/apps/beeai-ui/src/styles/components/_input.scss
+++ b/apps/beeai-ui/src/styles/components/_input.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @use 'styles/common' as *;
 
 .cds--text-area,

--- a/apps/beeai-ui/src/styles/components/_overflow-menu.scss
+++ b/apps/beeai-ui/src/styles/components/_overflow-menu.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @use 'styles/common' as *;
 
 .cds--overflow-menu__wrapper .cds--popover {

--- a/apps/beeai-ui/src/styles/components/_skeleton-styles.scss
+++ b/apps/beeai-ui/src/styles/components/_skeleton-styles.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @use 'styles/common' as *;
 
 .cds--skeleton__text {

--- a/apps/beeai-ui/src/styles/components/_tag.scss
+++ b/apps/beeai-ui/src/styles/components/_tag.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @use 'styles/common' as *;
 
 .cds--tag {

--- a/apps/beeai-ui/src/styles/style.scss
+++ b/apps/beeai-ui/src/styles/style.scss
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @use '@carbon/styles/scss/reset';
 @use '@carbon/styles/scss/fonts';
 @use '@carbon/styles/scss/grid';

--- a/apps/beeai-ui/src/utils/constants.ts
+++ b/apps/beeai-ui/src/utils/constants.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const GITHUB_REPO = { owner: 'i-am-bee', repo: 'beeai-framework' };
 
 export const GITHUB_REPO_LINK = `https://github.com/${GITHUB_REPO.owner}/${GITHUB_REPO.repo}`;

--- a/apps/beeai-ui/src/utils/formUtils.ts
+++ b/apps/beeai-ui/src/utils/formUtils.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { CODE_ENTER } from 'keycode-js';
 import { KeyboardEvent } from 'react';
 

--- a/apps/beeai-ui/src/utils/helpers.ts
+++ b/apps/beeai-ui/src/utils/helpers.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const noop = () => {};
 
 /**

--- a/apps/beeai-ui/src/utils/router.ts
+++ b/apps/beeai-ui/src/utils/router.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const routeDefinitions = {
   home: () => '/' as const,
   notFound: () => '/not-found' as const,

--- a/apps/beeai-ui/src/utils/strings.ts
+++ b/apps/beeai-ui/src/utils/strings.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export function isStringTerminalParameterSafe(value: string) {
   return /^[a-zA-Z0-9_-]*$/.test(value);
 }

--- a/apps/beeai-ui/src/vite-env.d.ts
+++ b/apps/beeai-ui/src/vite-env.d.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /// <reference types="./@types/svg" />
 /// <reference types="vite/client" />
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "update-openapi": "wget localhost:8333/api/v1/openapi.json -O api-reference/openapi.json"
   },
   "keywords": [],
-  "author": "",
+  "author": "IBM Corp.",
   "license": "ISC",
   "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1",
   "devDependencies": {

--- a/mise.lock
+++ b/mise.lock
@@ -16,6 +16,13 @@ pnpm-macos-arm64 = "sha256:0b396d48e9697588bfd4f3d40ed0d10d043432ecf1fe30dcdcad0
 version = "3.11.11"
 backend = "core:python"
 
+[tools."ubi:B1NARY-GR0UP/nwa"]
+version = "0.5.2"
+backend = "ubi:B1NARY-GR0UP/nwa"
+
+[tools."ubi:B1NARY-GR0UP/nwa".checksums]
+nwa-macos-aarch64 = "sha256:128c6bbae86b8725381355d04132d4d8e71d54a01313cea0d0c20a294d058c9f"
+
 [tools.uv]
 version = "0.6.2"
 backend = "aqua:astral-sh/uv"

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,7 @@ python = "3.11"
 nodejs = "22"
 uv = "latest"
 pnpm = "latest"
+"ubi:B1NARY-GR0UP/nwa" = "latest"
 
 [settings]
 experimental = true # for python.uv_venv_auto
@@ -76,4 +77,33 @@ hide = true
 dir = "{{config_root}}"
 run = "uv sync --all-extras"
 sources = ["uv.lock", "pyproject.toml", "apps/*/pyproject.toml", "packages/*/pyproject.toml"]
+outputs = { auto = true }
+
+## common tasks
+
+### check
+
+[tasks."common:check"]
+depends = ["common:check:*"]
+
+[tasks."common:check:nwa"]
+dir = "{{config_root}}"
+run = "nwa check -l apache -c 'IBM Corp.' --skip 'packages/acp-*-sdk/**/*' '{apps,packages}/*/src/**/*.{py,js,jsx,ts,tsx,html,css,scss}'"
+# sources don't support {a,b} -- https://github.com/jdx/mise/discussions/4469
+sources = ["apps/*/src/**/*.py", "packages/*/src/**/*.py", "apps/*/src/**/*.js", "packages/*/src/**/*.js", "apps/*/src/**/*.js*", "packages/*/src/**/*.js*", "apps/*/src/**/*.ts", "packages/*/src/**/*.ts", "apps/*/src/**/*.ts*", "packages/*/src/**/*.ts*", "apps/*/src/**/*.html", "packages/*/src/**/*.html", "apps/*/src/**/*.css", "packages/*/src/**/*.css", "apps/*/src/**/*.scss", "packages/*/src/**/*.scss"]
+outputs = { auto = true }
+
+### fix
+
+[tasks."common:fix"]
+depends = ["common:fix:*"]
+
+[tasks."common:fix:nwa"]
+dir = "{{config_root}}"
+run = """
+nwa update -l apache -c 'IBM Corp.' --skip 'packages/acp-*-sdk/**/*' '{apps,packages}/*/src/**/*.{py,js,jsx,ts,tsx,html,css,scss}' --mute || true
+nwa add    -l apache -c 'IBM Corp.' --skip 'packages/acp-*-sdk/**/*' '{apps,packages}/*/src/**/*.{py,js,jsx,ts,tsx,html,css,scss}' --mute || true
+"""
+# sources don't support {a,b} -- https://github.com/jdx/mise/discussions/4469
+sources = ["apps/*/src/**/*.py", "packages/*/src/**/*.py", "apps/*/src/**/*.js", "packages/*/src/**/*.js", "apps/*/src/**/*.js*", "packages/*/src/**/*.js*", "apps/*/src/**/*.ts", "packages/*/src/**/*.ts", "apps/*/src/**/*.ts*", "packages/*/src/**/*.ts*", "apps/*/src/**/*.html", "packages/*/src/**/*.html", "apps/*/src/**/*.css", "packages/*/src/**/*.css", "apps/*/src/**/*.scss", "packages/*/src/**/*.scss"]
 outputs = { auto = true }

--- a/packages/beeai-sdk/package.json
+++ b/packages/beeai-sdk/package.json
@@ -36,7 +36,7 @@
     "fix": "prettier --log-level silent --write src && eslint --fix src"
   },
   "keywords": [],
-  "author": "",
+  "author": "IBM Corp.",
   "license": "MIT",
   "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1",
   "devDependencies": {

--- a/packages/beeai-sdk/src/beeai_sdk/__init__.py
+++ b/packages/beeai-sdk/src/beeai_sdk/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/packages/beeai-sdk/src/beeai_sdk/index.ts
+++ b/packages/beeai-sdk/src/beeai_sdk/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file intentionally left blank.

--- a/packages/beeai-sdk/src/beeai_sdk/providers/agent.py
+++ b/packages/beeai-sdk/src/beeai_sdk/providers/agent.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import os
 

--- a/packages/beeai-sdk/src/beeai_sdk/providers/agent.ts
+++ b/packages/beeai-sdk/src/beeai_sdk/providers/agent.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import express from "express";
 import { AcpServer } from "@i-am-bee/acp-sdk/server/acp.js";
 import { SSEServerTransport } from "@i-am-bee/acp-sdk/server/sse.js";

--- a/packages/beeai-sdk/src/beeai_sdk/schemas/config.py
+++ b/packages/beeai-sdk/src/beeai_sdk/schemas/config.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from pydantic import BaseModel
 
 

--- a/packages/beeai-sdk/src/beeai_sdk/schemas/config.ts
+++ b/packages/beeai-sdk/src/beeai_sdk/schemas/config.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { z } from "zod";
 
 export const configSchema = z

--- a/packages/beeai-sdk/src/beeai_sdk/schemas/message.py
+++ b/packages/beeai-sdk/src/beeai_sdk/schemas/message.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Annotated, Literal, Union
 from pydantic import BaseModel, Discriminator
 

--- a/packages/beeai-sdk/src/beeai_sdk/schemas/message.ts
+++ b/packages/beeai-sdk/src/beeai_sdk/schemas/message.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { z } from "zod";
 
 export const messageSchema = z.union([

--- a/packages/beeai-sdk/src/beeai_sdk/schemas/metadata.py
+++ b/packages/beeai-sdk/src/beeai_sdk/schemas/metadata.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Optional
 from pydantic import BaseModel, ConfigDict
 

--- a/packages/beeai-sdk/src/beeai_sdk/schemas/metadata.ts
+++ b/packages/beeai-sdk/src/beeai_sdk/schemas/metadata.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { z } from "zod";
 
 export const metadataSchema = z

--- a/packages/beeai-sdk/src/beeai_sdk/schemas/prompt.py
+++ b/packages/beeai-sdk/src/beeai_sdk/schemas/prompt.py
@@ -1,3 +1,17 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from pydantic import BaseModel
 
 

--- a/packages/beeai-sdk/src/beeai_sdk/schemas/prompt.ts
+++ b/packages/beeai-sdk/src/beeai_sdk/schemas/prompt.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { z } from "zod";
 
 export const promptInputSchema = z.object({ prompt: z.string() });


### PR DESCRIPTION
- unify the `author` fields to `IBM Corp.`
- add LICENSE file (same as `beeai-framework`)
- `mise check` now also checks copyright headers with `nwa`
- `mise fix` now also fixes/adds copyright headers
- this is also a part of the pre-commit hooks and CI pipeline
- `acp-*-sdk` is skipped due to being MIT-licenced by the source

