### PR TITLE
feat: add mise.lock

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,7 +21,6 @@ runs:
       run: |
         echo "UV_FROZEN=true" >> $GITHUB_ENV
         echo "UV_PYTHON_PREFERENCE=only-system" >> $GITHUB_ENV
-        echo "MISE_NODE_GPG_VERIFY=false" >> $GITHUB_ENV
     
     - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8
       with:

--- a/mise.lock
+++ b/mise.lock
@@ -1,0 +1,24 @@
+[tools.node]
+version = "22.14.0"
+backend = "core:node"
+
+[tools.node.checksums]
+"node-v22.14.0-darwin-arm64.tar.gz" = "sha256:e9404633bc02a5162c5c573b1e2490f5fb44648345d64a958b17e325729a5e42"
+
+[tools.pnpm]
+version = "10.4.1"
+backend = "aqua:pnpm/pnpm"
+
+[tools.pnpm.checksums]
+pnpm-macos-arm64 = "sha256:0b396d48e9697588bfd4f3d40ed0d10d043432ecf1fe30dcdcad0f87b6d4140a"
+
+[tools.python]
+version = "3.11.11"
+backend = "core:python"
+
+[tools.uv]
+version = "0.6.2"
+backend = "aqua:astral-sh/uv"
+
+[tools.uv.checksums]
+"uv-aarch64-apple-darwin.tar.gz" = "sha256:4af802a1216053650dd82eee85ea4241994f432937d41c8b0bc90f2639e6ae14"

--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,7 @@ pnpm = "latest"
 experimental = true # for python.uv_venv_auto
 python.uv_venv_auto = true
 raw = true
+node.gpg_verify = false # tends to randomly fail; sha is checked by lockfile
 
 [hooks]
 postinstall = "{{ mise_bin }} setup"


### PR DESCRIPTION
- add lockfile for Mise: `mise.lock`
- disable Node.js GPG verification in `mise.toml` (it fails even locally)