### PR TITLE
feat(server): add  global env variables management and provisioning

### DIFF
--- a/apps/beeai-cli/src/beeai_cli/__init__.py
+++ b/apps/beeai-cli/src/beeai_cli/__init__.py
@@ -14,11 +14,13 @@
 
 from beeai_cli.async_typer import AsyncTyper
 import beeai_cli.commands.tool
+import beeai_cli.commands.env
 import beeai_cli.commands.agent
 import beeai_cli.commands.provider
 
 app = AsyncTyper()
 app.add_typer(beeai_cli.commands.tool.app, name="tool")
+app.add_typer(beeai_cli.commands.env.app, name="env")
 app.add_typer(beeai_cli.commands.agent.app, name="agent")
 app.add_typer(beeai_cli.commands.provider.app, name="provider")
 

--- a/apps/beeai-cli/src/beeai_cli/commands/agent.py
+++ b/apps/beeai-cli/src/beeai_cli/commands/agent.py
@@ -32,7 +32,7 @@ async def run(
     name: str = typer.Argument(help="Name of the tool to call"),
     input: str = typer.Argument(help="Agent input as JSON"),
 ) -> None:
-    """Call a tool with given input."""
+    """Call an agent with a given input."""
     try:
         parsed_input = json.loads(input)
     except json.JSONDecodeError:
@@ -64,6 +64,7 @@ async def run(
 
 @app.command("list")
 async def list_agents():
+    """List available agents"""
     result = await send_request(types.ListAgentsRequest(method="agents/list"), types.ListAgentsResult)
     extra_cols = list({col for agent in result.agents for col in agent.model_extra if col != "fullDescription"})
     table = Table("Name", "Description", *extra_cols, expand=True, show_lines=True)

--- a/apps/beeai-cli/src/beeai_cli/commands/env.py
+++ b/apps/beeai-cli/src/beeai_cli/commands/env.py
@@ -1,0 +1,58 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import typer
+from rich.table import Table
+
+from beeai_cli.api import api_request
+from beeai_cli.async_typer import AsyncTyper, console
+from beeai_cli.utils import parse_env_var
+
+app = AsyncTyper()
+
+
+@app.command("add")
+async def add(
+    env: list[str] = typer.Argument(help="Environment variables to pass to provider"),
+) -> None:
+    """Store environment variables"""
+    env_vars = [parse_env_var(var) for var in env]
+    env_vars = {name: value for name, value in env_vars}
+    await api_request(
+        "put",
+        "env",
+        json={**({"env": env_vars} if env_vars else {})},
+    )
+    typer.echo(f"Added env variables {list(env_vars.keys())}")
+
+
+@app.command("list")
+async def list_env():
+    """List stored environment variables"""
+    # TODO: extract server schemas to a separate package
+    resp = await api_request("get", "env")
+    table = Table("name", "value", expand=True)
+    for name, value in sorted(resp["env"].items()):
+        table.add_row(name, value)
+    console.print(table)
+
+
+@app.command(
+    "sync", help="Sync external changes to provider registry (if you modified ~/.beeai/providers.yaml manually)"
+)
+async def sync():
+    """Sync external changes to env configuration (if you modified ~/.beeai/.env manually)"""
+    await api_request("put", "env/sync")
+    console.print("Env updated")

--- a/apps/beeai-cli/src/beeai_cli/commands/tool.py
+++ b/apps/beeai-cli/src/beeai_cli/commands/tool.py
@@ -51,7 +51,8 @@ async def run(
 
 
 @app.command("list")
-async def list():
+async def list_tools():
+    """List available tools"""
     result = await send_request(types.ListToolsRequest(method="tools/list"), types.ListToolsResult)
     table = Table("Name", "Description", "Input Schema", expand=True)
     for tool in result.tools:

--- a/apps/beeai-server/src/beeai_server/adapters/filesystem.py
+++ b/apps/beeai-server/src/beeai_server/adapters/filesystem.py
@@ -14,15 +14,15 @@
 
 import logging
 from pathlib import Path
-from typing import AsyncIterator
 from uuid import uuid4
 
 import yaml
 from anyio import Path as AsyncPath
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, RootModel
 
-from beeai_server.adapters.interface import IProviderRepository
+from beeai_server.adapters.interface import IProviderRepository, IEnvVariableRepository, NOT_SET
 from beeai_server.domain.model import Provider
+from beeai_server.utils.utils import filter_dict
 
 
 class ProviderConfigFile(BaseModel):
@@ -32,41 +32,89 @@ class ProviderConfigFile(BaseModel):
 class FilesystemProviderRepository(IProviderRepository):
     def __init__(self, provider_config_path: Path):
         self._config_path = AsyncPath(provider_config_path)
+        self._repository_providers: list[Provider] | None = []
 
     async def _write_config(self, providers: list[Provider]) -> None:
         # Ensure that path exists
         await self._config_path.parent.mkdir(parents=True, exist_ok=True)
         config = yaml.dump(ProviderConfigFile(providers=providers).model_dump(mode="json"), indent=2)
+        # We do not handle conflicts - if the file was updated in the meantime, we override it with new values
         await self._config_path.write_text(config)
+        self._repository_providers = providers
 
-    async def _read_config(self) -> list[Provider]:
+    async def sync(self) -> None:
         if not await self._config_path.exists():
-            return []
+            self._repository_providers = []
+            return
 
         config = await self._config_path.read_text()
         try:
-            return ProviderConfigFile.model_validate(yaml.safe_load(config)).providers
+            self._repository_providers = ProviderConfigFile.model_validate(yaml.safe_load(config)).providers
         except ValidationError as ex:
             backup = self._config_path.parent / f"{self._config_path.name}.bak.{uuid4().hex[:6]}"
             logging.error(f"Invalid config file, renaming to {backup}. {ex!r}")
             await self._config_path.rename(backup)
-            return []
+            self._repository_providers = []
 
-    async def list(self) -> AsyncIterator[Provider]:
-        for provider in await self._read_config():
-            yield provider
+    async def list(self) -> list[Provider]:
+        if self._repository_providers is None:
+            await self.sync()
+        return self._repository_providers
 
     async def create(self, *, provider: Provider) -> None:
-        repository_providers = await self._read_config()
+        repository_providers = await self.list()
         if provider.id in {p.id for p in repository_providers}:
             raise ValueError(f"Provider with ID {provider.id} already exists")
         repository_providers.append(provider)
         await self._write_config(repository_providers)
 
     async def delete(self, *, provider_id: str) -> None:
-        repository_providers = await self._read_config()
+        repository_providers = await self.list()
         new_providers = [p for p in repository_providers if p.id != provider_id]
         if len(new_providers) < len(repository_providers):
             await self._write_config(new_providers)
             return
         raise ValueError(f"Provider with ID {provider_id} not found")
+
+
+EnvConfigFile = RootModel[dict[str, str]]
+
+
+class FilesystemEnvVariableRepository(IEnvVariableRepository):
+    def __init__(self, env_variable_path: Path):
+        self._env_file_path = AsyncPath(env_variable_path)
+        self._env: dict[str, str] | None = None
+
+    async def sync(self):
+        if not await self._env_file_path.exists():
+            self._env = {}
+            return
+        config = await self._env_file_path.read_text()
+        try:
+            self._env = EnvConfigFile.model_validate(yaml.safe_load(config)).root
+        except ValidationError as ex:
+            backup = self._env_file_path.parent / f"{self._env_file_path.name}.bak.{uuid4().hex[:6]}"
+            logging.error(f"Invalid config file, renaming to {backup}. {ex!r}")
+            await self._env_file_path.rename(backup)
+            self._env = {}
+
+    async def get_all(self) -> dict[str, str]:
+        if self._env is None:
+            await self.sync()
+        return self._env
+
+    async def _write_config(self, env: dict[str, str]) -> None:
+        # Ensure that path exists
+        await self._env_file_path.parent.mkdir(parents=True, exist_ok=True)
+        # We do not handle conflicts - if the file was updated in the meantime, we override it with new values
+        config = yaml.dump(EnvConfigFile(env).model_dump(mode="json"), indent=2)
+        await self._env_file_path.write_text(config)
+        self._env = env
+
+    async def get(self, key: str, default: str | None = NOT_SET) -> str:
+        env = await self.get_all()
+        return env.get(key) if default is NOT_SET else env.get(key, default)
+
+    async def update(self, update: dict[str, str | None]) -> None:
+        env = filter_dict({**await self.get_all(), **update})
+        await self._write_config(env)

--- a/apps/beeai-server/src/beeai_server/adapters/interface.py
+++ b/apps/beeai-server/src/beeai_server/adapters/interface.py
@@ -12,15 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import runtime_checkable, Protocol, AsyncIterator
+from typing import runtime_checkable, Protocol
 
 from beeai_server.domain.model import Provider
+
+NOT_SET = object()
 
 
 @runtime_checkable
 class IProviderRepository(Protocol):
-    async def list(self) -> AsyncIterator[Provider]:
-        yield
-
+    async def sync(self) -> None: ...
+    async def list(self) -> list[Provider]: ...
     async def create(self, *, provider: Provider) -> None: ...
     async def delete(self, *, provider_id: str) -> None: ...
+
+
+class IEnvVariableRepository(Protocol):
+    async def sync(self) -> None: ...
+    async def get(self, key: str, default: str | None = NOT_SET) -> str: ...
+    async def get_all(self) -> dict[str, str]: ...
+    async def update(self, update: dict[str, str | None]) -> None: ...

--- a/apps/beeai-server/src/beeai_server/application.py
+++ b/apps/beeai-server/src/beeai_server/application.py
@@ -32,6 +32,7 @@ from beeai_server.configuration import Configuration
 from beeai_server.exceptions import ManifestLoadError
 from beeai_server.routes.mcp_sse import create_mcp_sse_app
 from beeai_server.routes.provider import router as provider_router
+from beeai_server.routes.env import router as env_router
 from beeai_server.services.mcp_proxy.provider import ProviderContainer
 from beeai_server.utils.periodic import CRON_REGISTRY, run_all_crons
 
@@ -67,6 +68,7 @@ def mount_routes(app: FastAPI):
 
     server_router = APIRouter()
     server_router.include_router(provider_router, prefix="/provider", tags=["provider"])
+    server_router.include_router(env_router, prefix="/env", tags=["env"])
 
     app.mount("/healthcheck", lambda: "OK")
     app.mount("/mcp", create_mcp_sse_app())

--- a/apps/beeai-server/src/beeai_server/bootstrap.py
+++ b/apps/beeai-server/src/beeai_server/bootstrap.py
@@ -15,8 +15,8 @@
 from kink import di
 from acp.server.sse import SseServerTransport
 
-from beeai_server.adapters.filesystem import FilesystemProviderRepository
-from beeai_server.adapters.interface import IProviderRepository
+from beeai_server.adapters.filesystem import FilesystemProviderRepository, FilesystemEnvVariableRepository
+from beeai_server.adapters.interface import IProviderRepository, IEnvVariableRepository
 from beeai_server.configuration import Configuration, get_configuration
 from beeai_server.services.mcp_proxy.provider import ProviderContainer
 from beeai_server.utils.periodic import register_all_crons
@@ -27,6 +27,7 @@ def bootstrap_dependencies():
     di._aliases.clear()  # reset aliases
     di[Configuration] = get_configuration()
     di[IProviderRepository] = FilesystemProviderRepository(provider_config_path=di[Configuration].provider_config_path)
+    di[IEnvVariableRepository] = FilesystemEnvVariableRepository(env_variable_path=di[Configuration].env_path)
     di[SseServerTransport] = SseServerTransport("/mcp/messages/")  # global SSE transport
     di[ProviderContainer] = ProviderContainer()
 

--- a/apps/beeai-server/src/beeai_server/configuration.py
+++ b/apps/beeai-server/src/beeai_server/configuration.py
@@ -42,6 +42,7 @@ class Configuration(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", env_nested_delimiter="__")
     logging: LoggingConfiguration = LoggingConfiguration()
     provider_config_path: Path = Path.home() / ".beeai" / "providers.yaml"
+    env_path: Path = Path.home() / ".beeai" / ".env"
     cache_dir: Path = Path.home() / ".beeai" / "cache"
     port: int = 8333
     provider_registry_location: GithubUrl = "https://github.com/i-am-bee/beeai@main#path=provider-registry.yaml"

--- a/apps/beeai-server/src/beeai_server/crons/reload_external_changes.py
+++ b/apps/beeai-server/src/beeai_server/crons/reload_external_changes.py
@@ -17,6 +17,7 @@ from datetime import timedelta
 
 from kink import inject
 
+from beeai_server.services.env import EnvService
 from beeai_server.services.provider import ProviderService
 from beeai_server.utils.periodic import periodic
 
@@ -25,11 +26,11 @@ logger = logging.getLogger(__name__)
 
 @periodic(period=timedelta(minutes=1))
 @inject
-async def reload_providers(provider_service: ProviderService):
+async def reload_providers(provider_service: ProviderService, env_service: EnvService):
     """
-    Periodically reload providers from provider repository.
+    Periodically external changes to providers and environment variables.
 
-    Runs at server start to initialize the providers and then every minute to sync any modifications to the provider
-    registry (by default a configuration file at ~/.beeai/providers.yaml).
+    Useful when ~/.beeai/.env or ~/.beeai/providers.yaml is modified manually
     """
+    await env_service.sync()
     await provider_service.sync()

--- a/apps/beeai-server/src/beeai_server/crons/sync_registry_providers.py
+++ b/apps/beeai-server/src/beeai_server/crons/sync_registry_providers.py
@@ -44,10 +44,7 @@ async def check_official_registry(configuration: Configuration, provider_service
         resp = yaml.safe_load(resp.content)["providers"]
         for provider in resp:
             try:
-                provider_manifest = CreateProviderRequest(
-                    location=provider["url"],
-                    env=provider.get("env", None),
-                ).location
+                provider_manifest = CreateProviderRequest(location=provider["url"]).location
                 await provider_manifest.resolve()
                 desired_providers.add(provider_manifest.provider_id)
             except ValueError as e:

--- a/apps/beeai-server/src/beeai_server/domain/model.py
+++ b/apps/beeai-server/src/beeai_server/domain/model.py
@@ -27,14 +27,14 @@ from kink import inject
 from acp import stdio_client, StdioServerParameters
 from acp.client.sse import sse_client
 from packaging import version
-from pydantic import BaseModel, Field, FileUrl, RootModel, field_validator, model_validator
+from pydantic import BaseModel, Field, FileUrl, RootModel, field_validator
 from pydantic_core.core_schema import ValidationInfo
 
 from acp.client.stdio import get_default_environment
 from beeai_server.configuration import Configuration
 from beeai_server.custom_types import McpClient, ID
 from beeai_server.domain.constants import DEFAULT_MANIFEST_PATH
-from beeai_server.exceptions import UnsupportedProviderError
+from beeai_server.exceptions import UnsupportedProviderError, MissingConfigurationError
 from beeai_server.utils.github import GithubUrl, download_repo
 from beeai_server.utils.managed_server_client import managed_sse_client, ManagedServerParameters
 from beeai_server.utils.utils import which
@@ -72,11 +72,22 @@ class BaseProvider(BaseModel, abc.ABC):
 
     base_file_path: str | None = None
 
-    async def check(self) -> None:
+    def check_env(self, env: dict[str, str] | None = None, raise_error: bool = True) -> list[EnvVar]:
+        required_env = {var.name for var in self.env if var.required}
+        missing_env = [var for var in self.env if var.name in required_env - env.keys()]
+        if missing_env and raise_error:
+            raise MissingConfigurationError(missing_env=missing_env)
+        return missing_env
+
+    async def check_compatibility(self) -> None:
         pass
 
     @abc.abstractmethod
-    def mcp_client(self, *, env: dict[str, str] | None = None) -> McpClient: ...
+    async def mcp_client(self, *, env: dict[str, str] | None = None, with_dummy_env: bool = True) -> McpClient:
+        """
+        :param env: environment values passed to the process
+        :param with_dummy_env: substitute all unfilled required variables from manifest by "dummy" value
+        """
 
 
 class UnmanagedProvider(BaseProvider):
@@ -84,11 +95,8 @@ class UnmanagedProvider(BaseProvider):
     serverType: Literal[ServerType.http] = ServerType.http
     env: list[EnvVar] = Field(default_factory=list, description="Not supported for unmanaged provider", max_length=0)
 
-    async def check(self) -> None:
-        return
-
     @asynccontextmanager
-    async def mcp_client(self, *, env: dict[str, str] | None = None) -> McpClient:
+    async def mcp_client(self, *, env: dict[str, str] | None = None, with_dummy_env: bool = True) -> McpClient:
         match (self.serverType, self.mcpTransport):
             case (ServerType.http, McpTransport.sse):
                 async with sse_client(str(self.mcpEndpoint)) as client:
@@ -102,8 +110,15 @@ class ManagedProvider(BaseProvider, abc.ABC):
     command: list[str] = Field(description="Command with arguments to run")
 
     @asynccontextmanager
-    async def _get_mcp_client(self, *, command: list[str], env: dict[str, str] | None = None) -> McpClient:
-        env = env or {}
+    async def _get_mcp_client(
+        self, *, command: list[str], env: dict[str, str] | None = None, with_dummy_env: bool = True
+    ) -> McpClient:
+        declared_env_vars = {var.name for var in self.env}
+        required_env_vars = {var.name for var in self.env if var.required}
+        env = {
+            **({var: "dummy" for var in required_env_vars} if with_dummy_env else {}),
+            **({var: env[var] for var in env if var in declared_env_vars}),
+        }
         command, args = command[0], command[1:]
         match (self.serverType, self.mcpTransport):
             case (ServerType.stdio, _):
@@ -131,9 +146,10 @@ class NodeJsProvider(ManagedProvider):
         description='NPM package or "git+https://..." URL, or "file://..." URL (not allowed in remote manifests)',
     )
 
-    async def check(self):
+    async def check_compatibility(self) -> None:
         if not await which("npm"):
             raise UnsupportedProviderError("npm is not installed, see https://nodejs.org/en/download")
+        await super().check_compatibility()
 
     @field_validator("package", mode="after")
     @classmethod
@@ -148,8 +164,17 @@ class NodeJsProvider(ManagedProvider):
 
     @asynccontextmanager
     @inject
-    async def mcp_client(self, *, env: dict[str, str] | None = None, configuration: Configuration) -> McpClient:  # noqa: F821
-        await self.check()
+    async def mcp_client(
+        self,
+        *,
+        env: dict[str, str] | None = None,
+        with_dummy_env: bool = True,
+        configuration: Configuration,
+    ) -> McpClient:  # noqa: F821
+        await self.check_compatibility()
+        if not with_dummy_env:
+            await self.check_env(env)
+
         try:
             github_url = GithubUrl.model_validate(self.package)
             repo_path = await download_repo(configuration.cache_dir / "github_npm", github_url)
@@ -158,7 +183,9 @@ class NodeJsProvider(ManagedProvider):
             package = str(package_path)
         except ValueError:
             package = self.package
-        async with super()._get_mcp_client(command=["npx", "-y", package, *self.command], env=env) as client:
+        async with super()._get_mcp_client(
+            command=["npx", "-y", package, *self.command], env=env, with_dummy_env=with_dummy_env
+        ) as client:
             yield client
 
 
@@ -170,11 +197,12 @@ class PythonProvider(ManagedProvider):
         description='PyPI package or "git+https://..." URL, or "file://..." URL (not allowed in remote manifests)',
     )
 
-    async def check(self) -> None:
+    async def check_compatibility(self) -> None:
         if not await which("uvx"):
             raise UnsupportedProviderError(
                 "uv is not installed, see https://docs.astral.sh/uv/getting-started/installation/"
             )
+        await super().check_compatibility()
 
     @field_validator("pythonVersion", mode="after")
     @classmethod
@@ -196,12 +224,16 @@ class PythonProvider(ManagedProvider):
         return value
 
     @asynccontextmanager
-    async def mcp_client(self, *, env: dict[str, str] | None = None) -> McpClient:  # noqa: F821
-        await self.check()
+    async def mcp_client(self, *, env: dict[str, str] | None = None, with_dummy_env=True) -> McpClient:
+        await self.check_compatibility()
+        if not with_dummy_env:
+            await self.check_env(env)
+
         python = [] if not self.pythonVersion else ["--python", self.pythonVersion]
         async with super()._get_mcp_client(
             command=["uvx", *python, "--from", self.package, "--reinstall", *self.command],
             env=env,
+            with_dummy_env=with_dummy_env,
         ) as client:
             yield client
 
@@ -213,18 +245,22 @@ class ContainerProvider(ManagedProvider):
 
     _runtime = "docker"
 
-    async def check(self) -> None:
+    async def check_compatibility(self) -> None:
         if await which("docker"):
-            return
-        if await which("podman"):
+            self._runtime = "docker"
+        elif await which("podman"):
             self._runtime = "podman"
-            return
-        raise UnsupportedProviderError("docker is not installed, see https://docs.docker.com/get-started/get-docker/")
+        else:
+            raise UnsupportedProviderError("docker is not installed, see https://docs.docker.com/get-started/")
+        await super().check_compatibility()
 
     @asynccontextmanager
-    async def mcp_client(self, *, env: dict[str, str] | None = None) -> McpClient:  # noqa: F821
-        await self.check()
-        env_args = [f"-e={var}" for var in list((env or {})) + ["PORT"]]
+    async def mcp_client(self, *, env: dict[str, str] | None = None, with_dummy_env: bool = True) -> McpClient:  # noqa: F821
+        await self.check_compatibility()
+        if not with_dummy_env:
+            self.check_env(env)
+
+        env_args = [f"-e={var.name}" for var in self.env] + ["-e=PORT"]
         name = uuid.uuid4().hex
         try:
             async with super()._get_mcp_client(
@@ -240,6 +276,7 @@ class ContainerProvider(ManagedProvider):
                     *self.command,
                 ],
                 env=env,
+                with_dummy_env=with_dummy_env,
             ) as client:
                 yield client
         finally:
@@ -250,23 +287,15 @@ class ContainerProvider(ManagedProvider):
 ProviderManifest = UnmanagedProvider | NodeJsProvider | PythonProvider | ContainerProvider
 
 
-class Provider(BaseModel):
+class Provider(BaseModel, extra="allow"):
     manifest: ProviderManifest
     id: ID
     registry: GithubUrl | None = None
-    env: dict[str, str] | None = None
 
     @asynccontextmanager
-    async def mcp_client(self) -> McpClient:
-        async with self.manifest.mcp_client(env=self.env) as client:
+    async def mcp_client(self, *, env: dict[str, str] | None = None, with_dummy_env: bool = True) -> McpClient:
+        async with self.manifest.mcp_client(env=env, with_dummy_env=with_dummy_env) as client:
             yield client
-
-    @model_validator(mode="after")
-    def level_uvicorn_validator(self):
-        required_vars = set(var.name for var in self.manifest.env if var.required)
-        if missing_vars := required_vars - (self.env or {}).keys():
-            raise ValueError(f"The following required variables are missing : {missing_vars}")
-        return self
 
 
 class LoadedProviderStatus(StrEnum):
@@ -276,9 +305,14 @@ class LoadedProviderStatus(StrEnum):
     unsupported = "unsupported"
 
 
+class LoadProviderErrorMessage(BaseModel):
+    message: str
+
+
 class ProviderWithStatus(Provider):
     status: LoadedProviderStatus
     last_error: str | None = None
+    missing_configuration: list[EnvVar] = Field(default_factory=list)
 
 
 class GitHubManifestLocation(RootModel):

--- a/apps/beeai-server/src/beeai_server/exceptions.py
+++ b/apps/beeai-server/src/beeai_server/exceptions.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import TYPE_CHECKING
+
 from starlette.status import HTTP_404_NOT_FOUND
+
+
+if TYPE_CHECKING:
+    from beeai_server.domain.model import EnvVar
 
 
 class ManifestLoadError(Exception):
@@ -29,3 +35,8 @@ class LoadFeaturesError(Exception): ...
 
 
 class UnsupportedProviderError(FileNotFoundError): ...
+
+
+class MissingConfigurationError(Exception):
+    def __init__(self, missing_env: list["EnvVar"]):
+        self.missing_env = missing_env

--- a/apps/beeai-server/src/beeai_server/routes/dependencies.py
+++ b/apps/beeai-server/src/beeai_server/routes/dependencies.py
@@ -14,6 +14,7 @@
 
 from typing import Annotated
 
+from beeai_server.services.env import EnvService
 from beeai_server.services.mcp_proxy.proxy_server import MCPProxyServer
 from fastapi import Depends
 from kink import di
@@ -22,5 +23,6 @@ from beeai_server.services.provider import ProviderService
 from acp.server.sse import SseServerTransport
 
 ProviderServiceDependency = Annotated[ProviderService, Depends(lambda: di[ProviderService])]
+EnvServiceDependency = Annotated[EnvService, Depends(lambda: di[EnvService])]
 SSEServerTransportDependency = Annotated[SseServerTransport, Depends(lambda: di[SseServerTransport])]
 MCPProxyServerDependency = Annotated[MCPProxyServer, Depends(lambda: di[MCPProxyServer])]

--- a/apps/beeai-server/src/beeai_server/routes/env.py
+++ b/apps/beeai-server/src/beeai_server/routes/env.py
@@ -1,0 +1,37 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import fastapi
+
+from beeai_server.routes.dependencies import EnvServiceDependency
+from beeai_server.schema import UpdateEnvRequest
+
+router = fastapi.APIRouter()
+
+
+@router.put("")
+async def update_env(request: UpdateEnvRequest, env_service: EnvServiceDependency):
+    await env_service.update_env(env=request.env)
+    return fastapi.Response(status_code=fastapi.status.HTTP_201_CREATED)
+
+
+@router.get("")
+async def list_env(env_service: EnvServiceDependency):
+    return {"env": await env_service.list_env()}
+
+
+@router.put("/sync")
+async def sync_provider_repository(env_service: EnvServiceDependency):
+    """Sync external changes to an env repository."""
+    await env_service.sync()

--- a/apps/beeai-server/src/beeai_server/routes/provider.py
+++ b/apps/beeai-server/src/beeai_server/routes/provider.py
@@ -22,8 +22,7 @@ router = fastapi.APIRouter()
 
 @router.post("")
 async def create_provider(request: CreateProviderRequest, provider_service: ProviderServiceDependency):
-    await provider_service.add_provider(location=request.location, env=request.env)
-    return fastapi.Response(status_code=fastapi.status.HTTP_201_CREATED)
+    return await provider_service.add_provider(location=request.location)
 
 
 @router.get("")

--- a/apps/beeai-server/src/beeai_server/schema.py
+++ b/apps/beeai-server/src/beeai_server/schema.py
@@ -27,7 +27,10 @@ class PaginatedResponse(BaseModel, Generic[BaseModelT]):
 
 class CreateProviderRequest(BaseModel):
     location: ManifestLocation
-    env: dict[str, str] | None = None
+
+
+class UpdateEnvRequest(BaseModel):
+    env: dict[str, str]
 
 
 DeleteProviderRequest = CreateProviderRequest

--- a/apps/beeai-server/src/beeai_server/services/env.py
+++ b/apps/beeai-server/src/beeai_server/services/env.py
@@ -1,0 +1,35 @@
+# Copyright 2025 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kink import inject
+
+from beeai_server.adapters.interface import IEnvVariableRepository
+from beeai_server.services.mcp_proxy.provider import ProviderContainer
+
+
+@inject
+class EnvService:
+    def __init__(self, env_repository: IEnvVariableRepository, loaded_provider_container: ProviderContainer):
+        self._repository = env_repository
+        self._loaded_provider_container = loaded_provider_container
+
+    async def update_env(self, *, env: dict[str, str | None]) -> None:
+        await self._repository.update(env)
+        self._loaded_provider_container.handle_reload_on_env_update()
+
+    async def list_env(self) -> dict[str, str]:
+        return await self._repository.get_all()
+
+    async def sync(self):
+        await self._repository.sync()


### PR DESCRIPTION
closes: #141 

Added global environment variable management.

## Manifest
A provider can declare required and optional environment variables in the manifest:
```
manifestVersion: 1
driver: container
image: test-manifest:local
serverType: http
mcpTransport: sse
mcpEndpoint: /sse
env:
  - required: True
    name: 'TEST_VAR'
    description: 'my test variable'
```

## Providers
- A provider with this manifest can be added and will be executed even if required variables are not fullfiled.  
- There will be "dummy" values supplied for all unfulfilled required values. This naive approach will let us list agents in some cases, but there may still be problems when there is for example validation of env variables.

You can get the list of missing required variables in `beeai list provider`.

UI can get this information using the `http://localhost:8333/api/v1/provider` endpoint.

### Provider status
Provider can be in 4 states:
- `unsupported` (backend such as docker is not installed)
- `initializing`
- `ready`
- `error`

The state is independent from missing configuration issue. A provider with missing variables can be in state "ready", you can list its agents, but they probably won't work.

This is because a provider with missing variables can still fail to execute for a different reason which we want to track separately.

### Agents
UI can list agents from a provider with missing configuration as usual. New `provider` field was added to agent metadata to determine whether the agent is ready to run and what configuration is missing. The interaction pattern when clicking on the "Try this agent button":
1. list agents
2. list providers
3. providers.find(agent.provider)
4. if provider.missing_configuration -> cannot use agent, show modal to fill configuration variables
5. add env variables
6. wait for provider to reload (state will switch to initializing -> ready or error)
7. profit

## Env variables
- Environment variables can be registered using `beeai env add NAME=value NAME2=value2`.
- They will be stored by the server in `~/.beeai/.env`
- Env variables are not protected, encrypted or otherwise secured. They will be stored in plaintext on your filesystem. This is probably fine and not new, see [`~/.git-credentials`](https://git-scm.com/docs/git-credential-store)

UI can store env variables using `PUT /api/v1/env` with payload `{"env": {"NAME": "value"}}`. Sending `null` value should remove the variable.

Here is a complete example of the interaction in CLI:

![Screenshot 2025-02-20 at 21 06 46](https://github.com/user-attachments/assets/63bd0136-d6d9-41c1-8e37-746323f6da69)
 