### PR TITLE
fix(web): listAgents on every request for true SSR

### DIFF
--- a/apps/beeai-web/src/acp/client.ts
+++ b/apps/beeai-web/src/acp/client.ts
@@ -19,20 +19,18 @@ import { Client } from "@i-am-bee/acp-sdk/client/index.js";
 import type { ServerCapabilities } from "@i-am-bee/acp-sdk/types.js";
 import { SSEClientTransport } from "@i-am-bee/acp-sdk/client/sse.js";
 import { BEEAI_HOST } from "@/constants";
+import { getNativeFetch } from "./native-fetch";
 
 export async function getAcpClient() {
   if (!ACP_SSE_TRANSPORT_URL) {
     throw new Error("ACP Transport has not been set");
   }
+
   const transport = new SSEClientTransport(ACP_SSE_TRANSPORT_URL, {
     eventSourceInit: {
-      fetch: (url, init) => {
-        // SSEClientTransport adds `cache: 'no-store'` to the fetch, that causes error during nextjs SSG
-        if (init != null && init.cache != null) {
-          delete init.cache;
-        }
-        return fetch(url, init);
-      },
+      // Use native nodejs fetch instead of nextjs patched one, we don't want
+      // any nextjs caching/deduping behaviour here.
+      fetch: getNativeFetch(),
     },
   });
   const client = new Client(ACP_EXAMPLE_AGENT_CONFIG, ACP_EXAMPLE_AGENT_PARAMS);

--- a/apps/beeai-web/src/acp/native-fetch.ts
+++ b/apps/beeai-web/src/acp/native-fetch.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2025 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This needs to be `Symbol.for()` because this module is evaluated separately during instrumentation and then
+// for next-server so just a `Symbol()` would not work
+const NATIVE_FETCH = Symbol.for('beeai-native-fetch');
+
+export function getNativeFetch() {
+  return (globalThis as Record<symbol, unknown>)[NATIVE_FETCH] as typeof globalThis.fetch;
+}
+
+/**
+ * Run this during instrumentation, when native unpatched fetch is still available on globalThis
+ * We will store it as a symbol global variable. This global variable will be then still available
+ * during normal next-server operation
+ */
+export function storeNativeFetch() {
+  (globalThis as Record<symbol, unknown>)[NATIVE_FETCH] = globalThis.fetch;
+}

--- a/apps/beeai-web/src/instrumentation.ts
+++ b/apps/beeai-web/src/instrumentation.ts
@@ -14,18 +14,7 @@
  * limitations under the License.
  */
 
-import { cache } from "react";
-import { getAcpClient } from "./client";
-
-export const getAgentsList = cache(
-  async () => {
-    let client: Awaited<ReturnType<typeof getAcpClient>> | undefined;
-    try {
-      client = await getAcpClient();
-      const { agents } = await client.listAgents();
-      return agents;
-    } finally {
-      await client?.close();
-    }
-  },
-);
+export async function register() {
+  const { storeNativeFetch } = await import('./acp/native-fetch');
+  storeNativeFetch();
+}


### PR DESCRIPTION
Do not use `unstable_cache` from nextjs that caches result agresively, just use `cache` from react to dedupe calls in single request

Because nextjs patched fetch doesn't play nicely with acp client implementation we provide native nodejs fetch to the underlying eventsource