### PR TITLE
fix(web): css order and add active links

### DIFF
--- a/apps/beeai-web/next.config.ts
+++ b/apps/beeai-web/next.config.ts
@@ -42,6 +42,26 @@ const nextConfig: NextConfig = {
 
     return config;
   },
+  experimental: {
+    // Disable CSS chunking due to persistent nextjs bug with ordering of css and this seems to help partially.
+    // Nextjs in production build only! puts global styles last so it messes up css specificity.
+    //
+    // We get css modules styles twice but atleast the second css file overwrites them in correct order.
+    //
+    // I think it's actually two issues, first is with sideEffects and external packages, because beeai-ui doesn't
+    // have `sideEffects: false` in package.json and I don't wanna add it because it's vite app, not a library
+    // and we have single `index.ts` in it that exports everything, nextjs bundler doesn't tree shake and sees
+    // all styles as required in a root layout. Having separate exports in package.json helps but doesn't mitigrate
+    // the issue completely see second issue bellow.
+    //
+    // The second issue is IMHO when the same component is imported from the page and layout and from RSC and from
+    // client component simultaneously, this breaks nextjs and as a result puts global styles after css modules styles.
+    // In our codebase it's a case of a Container component. I wasn't able to refactor this cleanly hence this workaround
+    //
+    // https://github.com/vercel/next.js/issues/68207
+    // https://github.com/vercel/next.js/issues/64921
+    cssChunking: false
+  }
 };
 
 export default nextConfig;

--- a/apps/beeai-web/src/components/MainNav/MainNav.module.scss
+++ b/apps/beeai-web/src/components/MainNav/MainNav.module.scss
@@ -14,17 +14,28 @@
  * limitations under the License.
  */
 
-.list {
+ .list {
   display: flex;
-  column-gap: $spacing-07;
+  column-gap: $spacing-05;
+
+  li {
+    border-block-end: 2px solid transparent;
+    &.active {
+      border-color: $background-inverse;
+    }
+  }
 }
 
 .link {
-  display: block;
+  display: flex;
+  block-size: rem(48px);
+  align-items: center;
+  padding-inline: $spacing-04;
   font-size: rem(14px);
   line-height: math.div(18, 14);
   color: $text-dark;
   text-decoration: none;
+
   &:hover {
     color: $background-inverse;
   }

--- a/apps/beeai-web/src/components/MainNav/MainNav.tsx
+++ b/apps/beeai-web/src/components/MainNav/MainNav.tsx
@@ -14,15 +14,25 @@
  * limitations under the License.
  */
 
+"use client";
+
+import clsx from "clsx";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import classes from "./MainNav.module.scss";
 
 export function MainNav() {
+  const pathname = usePathname();
   return (
     <nav>
       <ul className={classes.list}>
-        {NAV_ITEMS.map(({ label, href }, idx) => (
-          <li key={idx}>
+        {NAV_ITEMS.map(({ label, href, isSection }, idx) => (
+          <li
+            key={idx}
+            className={clsx({
+              [classes.active]: isSection && pathname.startsWith(href),
+            })}
+          >
             <Link href={href} className={classes.link}>
               {label}
             </Link>
@@ -39,7 +49,8 @@ const NAV_ITEMS = [
     href: "/",
   },
   {
-    label: 'Agents',
-    href: '/agents',
-  }
+    label: "Agents",
+    href: "/agents",
+    isSection: true,
+  },
 ];


### PR DESCRIPTION
Disable CSS chunking due to persistent nextjs bug with ordering of css and this seems to help partially.
Nextjs in production build only! puts global styles last so it messes up css specificity.

We get css modules styles twice but atleast the second css file overwrites them in correct order.

I think it's actually two issues, first is with sideEffects and external packages, because beeai-ui doesn't
have `sideEffects: false` in package.json and I don't wanna add it because it's vite app, not a library
and we have single `index.ts` in it that exports everything, nextjs bundler doesn't tree shake and sees
all styles as required in a root layout. Having separate exports in package.json helps but doesn't mitigate
the issue completely see second issue bellow.

The second issue is IMHO when the same component is imported from the page and layout and from RSC and from
client component simultaneously, this breaks nextjs and as a result puts global styles after css modules styles.
In our codebase it's a case of a Container component. I wasn't able to refactor this cleanly hence this workaround

https://github.com/vercel/next.js/issues/68207
https://github.com/vercel/next.js/issues/64921