### PR TITLE
chore(web): rename ACP_CLIENT_SERVER_URL env

### DIFF
--- a/apps/beeai-web/.env.example
+++ b/apps/beeai-web/.env.example
@@ -1,1 +1,1 @@
-MCP_CLIENT_SERVER_URL="http://localhost:8333/mcp/sse"
+ACP_CLIENT_SERVER_URL="http://localhost:8333/mcp/sse"

--- a/apps/beeai-web/.env.example
+++ b/apps/beeai-web/.env.example
@@ -1,0 +1,1 @@
+MCP_CLIENT_SERVER_URL="http://localhost:8333/mcp/sse"

--- a/apps/beeai-web/src/acp/client.ts
+++ b/apps/beeai-web/src/acp/client.ts
@@ -18,15 +18,15 @@ import "server-only";
 import { Client } from "@i-am-bee/acp-sdk/client/index.js";
 import type { ServerCapabilities } from "@i-am-bee/acp-sdk/types.js";
 import { SSEClientTransport } from "@i-am-bee/acp-sdk/client/sse.js";
-import { BEEAI_HOST } from "@/constants";
+import { MCP_CLIENT_SERVER_URL } from "@/constants";
 import { getNativeFetch } from "./native-fetch";
 
 export async function getAcpClient() {
-  if (!ACP_SSE_TRANSPORT_URL) {
+  if (!MCP_CLIENT_SERVER_URL) {
     throw new Error("ACP Transport has not been set");
   }
 
-  const transport = new SSEClientTransport(ACP_SSE_TRANSPORT_URL, {
+  const transport = new SSEClientTransport(new URL(MCP_CLIENT_SERVER_URL), {
     eventSourceInit: {
       // Use native nodejs fetch instead of nextjs patched one, we don't want
       // any nextjs caching/deduping behaviour here.
@@ -51,7 +51,6 @@ function assertServerCapability(
   }
 }
 
-const ACP_SSE_TRANSPORT_URL = BEEAI_HOST ? new URL(BEEAI_HOST) : undefined;
 const ACP_EXAMPLE_AGENT_CONFIG = {
   name: "example-client",
   version: "1.0.0",

--- a/apps/beeai-web/src/acp/client.ts
+++ b/apps/beeai-web/src/acp/client.ts
@@ -18,15 +18,15 @@ import "server-only";
 import { Client } from "@i-am-bee/acp-sdk/client/index.js";
 import type { ServerCapabilities } from "@i-am-bee/acp-sdk/types.js";
 import { SSEClientTransport } from "@i-am-bee/acp-sdk/client/sse.js";
-import { MCP_CLIENT_SERVER_URL } from "@/constants";
+import { ACP_CLIENT_SERVER_URL } from "@/constants";
 import { getNativeFetch } from "./native-fetch";
 
 export async function getAcpClient() {
-  if (!MCP_CLIENT_SERVER_URL) {
+  if (!ACP_CLIENT_SERVER_URL) {
     throw new Error("ACP Transport has not been set");
   }
 
-  const transport = new SSEClientTransport(new URL(MCP_CLIENT_SERVER_URL), {
+  const transport = new SSEClientTransport(new URL(ACP_CLIENT_SERVER_URL), {
     eventSourceInit: {
       // Use native nodejs fetch instead of nextjs patched one, we don't want
       // any nextjs caching/deduping behaviour here.

--- a/apps/beeai-web/src/constants.ts
+++ b/apps/beeai-web/src/constants.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const MCP_CLIENT_SERVER_URL = process.env.MCP_CLIENT_SERVER_URL;
+export const ACP_CLIENT_SERVER_URL = process.env.ACP_CLIENT_SERVER_URL;

--- a/apps/beeai-web/src/constants.ts
+++ b/apps/beeai-web/src/constants.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const BEEAI_HOST = process.env.BEEAI_HOST;
+export const MCP_CLIENT_SERVER_URL = process.env.MCP_CLIENT_SERVER_URL;


### PR DESCRIPTION
I renamed `BEEAI_HOST` to `ACP_CLIENT_SERVER_URL` since the full URL to the ACP client server is expected now.