### PR TITLE
fix(ui): track sequential run steps progress

### DIFF
--- a/apps/beeai-ui/src/modules/compose/components/ComposeStepListItem.tsx
+++ b/apps/beeai-ui/src/modules/compose/components/ComposeStepListItem.tsx
@@ -43,11 +43,11 @@ export function ComposeStepListItem({ idx }: Props) {
   };
 
   const step = watch(`steps.${idx}`);
-  const { data, isPending, result, instruction } = step;
+  const { data, isPending, stats, instruction } = step;
   const { name } = data;
 
   const isViewMode = status !== 'ready';
-  const isFinished = Boolean(!isPending && result);
+  const isFinished = Boolean(!isPending && stats?.endTime);
 
   return (
     <div className={clsx(classes.root, classes[`status-${isPending ? 'pending' : isFinished ? 'finished' : 'ready'}`])}>

--- a/apps/beeai-ui/src/modules/compose/types.ts
+++ b/apps/beeai-ui/src/modules/compose/types.ts
@@ -23,8 +23,6 @@ export const composeNotificationSchema = AgentRunProgressNotificationSchema.exte
     delta: outputSchema.extend({
       agent_idx: z.number(),
       agent_name: z.string(),
-      logs: z.array(z.object({ message: z.string() }).nullable()),
-      text: z.string().optional().nullable(),
     }),
   }),
 });


### PR DESCRIPTION
Visual feedback of step progress in the sequential workflow was broken because some agents don’t send notifications, leaving the UI without data to indicate when a step starts executing. However, a success notification is sent (without a step index), so I now process them sequentially—ending the currently pending step and starting a new one if available.