### PR TITLE
feat(phoenix): add traces button (#241)

### DIFF
--- a/apps/beeai-ui/src/components/MainNav/MainNav.tsx
+++ b/apps/beeai-ui/src/components/MainNav/MainNav.tsx
@@ -38,8 +38,8 @@ export function MainNav() {
         }).map(({ label, to, section, target, rel, isDisabled }, idx) => (
           <li key={idx} className={clsx({ [classes.active]: section && isSectionActive(section) })}>
             {isDisabled ? (
-              <Tooltip asChild content={<TracesTooltip></TracesTooltip>}>
-                <Button kind="ghost" disabled>
+              <Tooltip asChild content={<TracesTooltip />}>
+                <Button kind="ghost" disabled className={classes.link}>
                   {label}
                 </Button>
               </Tooltip>

--- a/apps/beeai-ui/src/components/MainNav/MainNav.tsx
+++ b/apps/beeai-ui/src/components/MainNav/MainNav.tsx
@@ -19,18 +19,39 @@ import classes from './MainNav.module.scss';
 import { TransitionLink } from '../TransitionLink/TransitionLink';
 import { useIsNavSectionActive } from '#hooks/useIsNavSectionActive.ts';
 import clsx from 'clsx';
+import { usePhoenix } from './queries/usePhoenix';
+import { Button } from '@carbon/react';
+import { Tooltip } from '#components/Tooltip/Tooltip.tsx';
+import { TracesTooltip } from './TracesTooltip';
 
 export function MainNav() {
   const isSectionActive = useIsNavSectionActive();
+  const { isPending, error, data: showPhoenixTab } = usePhoenix({ enabled: Boolean(__PHOENIX_SERVER_TARGET__) });
 
   return (
     <nav>
       <ul className={classes.list}>
-        {NAV_ITEMS.map(({ label, to, section }, idx) => (
+        {getNavItems({
+          appName: __APP_NAME__,
+          phoenixServerTarget: __PHOENIX_SERVER_TARGET__,
+          showPhoenixTab: Boolean(!isPending && !error && showPhoenixTab),
+        }).map(({ label, to, section, target, rel, isDisabled }, idx) => (
           <li key={idx} className={clsx({ [classes.active]: section && isSectionActive(section) })}>
-            <TransitionLink to={to} className={classes.link}>
-              {label}
-            </TransitionLink>
+            {isDisabled ? (
+              <Tooltip asChild content={<TracesTooltip></TracesTooltip>}>
+                <Button kind="ghost" disabled>
+                  {label}
+                </Button>
+              </Tooltip>
+            ) : target ? (
+              <a href={to} className={classes.link} target={target} rel={rel}>
+                {label}
+              </a>
+            ) : (
+              <TransitionLink to={to} className={classes.link}>
+                {label}
+              </TransitionLink>
+            )}
           </li>
         ))}
       </ul>
@@ -38,19 +59,36 @@ export function MainNav() {
   );
 }
 
-const NAV_ITEMS = [
-  {
-    label: <strong>{__APP_NAME__}</strong>,
-    to: routes.home(),
-  },
-  {
-    label: 'Agents',
-    to: routes.agents(),
-    section: sections.agents,
-  },
-  {
-    label: 'Compose playground',
-    to: routes.compose(),
-    section: sections.compose,
-  },
-];
+function getNavItems({
+  appName,
+  phoenixServerTarget,
+  showPhoenixTab,
+}: {
+  appName: string;
+  phoenixServerTarget: string;
+  showPhoenixTab: boolean;
+}) {
+  return [
+    {
+      label: <strong>{appName}</strong>,
+      to: routes.home(),
+    },
+    {
+      label: 'Agents',
+      to: routes.agents(),
+      section: sections.agents,
+    },
+    {
+      label: 'Compose playground',
+      to: routes.compose(),
+      section: sections.compose,
+    },
+    {
+      label: 'Traces',
+      to: `${phoenixServerTarget}/projects`,
+      target: '_blank',
+      rel: 'noopener noreferrer', // Security best practice
+      isDisabled: Boolean(!showPhoenixTab || !phoenixServerTarget),
+    },
+  ];
+}

--- a/apps/beeai-ui/src/components/MainNav/TracesTooltip.tsx
+++ b/apps/beeai-ui/src/components/MainNav/TracesTooltip.tsx
@@ -14,8 +14,22 @@
  * limitations under the License.
  */
 
-/// <reference types="./@types/svg" />
-/// <reference types="vite/client" />
-
-declare const __APP_NAME__: string;
-declare const __PHOENIX_SERVER_TARGET__: string;
+export function TracesTooltip() {
+  return (
+    <>
+      <strong>Phoenix Server Unavailable 🚨</strong>
+      <br />
+      <br />
+      It looks like the Phoenix server is not running or cannot be reached.
+      <br />
+      <br />
+      To enable traceability and ensure everything works smoothly, please check your Phoenix setup by following the
+      instructions in the official documentation:
+      <br />
+      🔗{' '}
+      <a href="https://docs.beeai.dev/observability/agents-traceability" target={'_blank'}>
+        Set up Phoenix Server
+      </a>
+    </>
+  );
+}

--- a/apps/beeai-ui/src/components/MainNav/queries/usePhoenix.ts
+++ b/apps/beeai-ui/src/components/MainNav/queries/usePhoenix.ts
@@ -14,8 +14,17 @@
  * limitations under the License.
  */
 
-/// <reference types="./@types/svg" />
-/// <reference types="vite/client" />
+import { useQuery } from '@tanstack/react-query';
 
-declare const __APP_NAME__: string;
-declare const __PHOENIX_SERVER_TARGET__: string;
+interface Props {
+  enabled: boolean;
+}
+
+export function usePhoenix({ enabled }: Props) {
+  return useQuery({
+    queryKey: ['phoenix'],
+    refetchInterval: 60_000,
+    enabled,
+    queryFn: () => fetch('/phoenix').then((res) => res.ok),
+  });
+}

--- a/apps/beeai-ui/src/components/Tooltip/Tooltip.module.scss
+++ b/apps/beeai-ui/src/components/Tooltip/Tooltip.module.scss
@@ -24,11 +24,15 @@
   color: $text-inverse;
   border-radius: $border-radius;
   max-inline-size: rem(264px);
+
   .root.sm & {
     padding: $spacing-02 $spacing-03;
   }
   .root.md & {
-    padding: $spacing-03 $spacing-05;
+    padding: $spacing-04 $spacing-05;
+  }
+  a {
+    color: $link-inverse;
   }
 }
 

--- a/apps/beeai-ui/vite.config.ts
+++ b/apps/beeai-ui/vite.config.ts
@@ -4,6 +4,8 @@ import { fileURLToPath, URL } from 'url';
 import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
+const phoenixServerTarget = 'http://localhost:6006';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -13,6 +15,7 @@ export default defineConfig({
   ],
   define: {
     __APP_NAME__: JSON.stringify('BeeAI'),
+    __PHOENIX_SERVER_TARGET__: JSON.stringify(phoenixServerTarget),
   },
   server: {
     proxy: {
@@ -22,6 +25,9 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:8333',
       },
+      '/phoenix': {
+        target: phoenixServerTarget
+      }
     },
   },
   resolve: {


### PR DESCRIPTION
I added a new "Traces" tab to the menu, that is enabled only when the Phoenix server is running. Otherwise, the disabled item with the tooltip with the link to the Observability documentation part is visualized. 

It works only locally. (the Phoenix server target is set to `http://localhost:6006`) the same way as for mcp and API proxy. See `vite.config.ts` for more details. 

The state is checked every 60 seconds. 