### PR TITLE
fix: Use the selected model name for the modified long-context model

### DIFF
--- a/apps/beeai-cli/src/beeai_cli/commands/env.py
+++ b/apps/beeai-cli/src/beeai_cli/commands/env.py
@@ -227,7 +227,7 @@ async def setup() -> bool:
         )
         > 2048
     ):
-        modified_model = f"{recommended_model}-beeai"
+        modified_model = f"{selected_model}-beeai"
         console.print(
             f"⚠️  [yellow]Warning[/yellow]: BeeAI will create and use a modified version of this model tagged [bold]{modified_model}[/bold] with default context window set to [bold]{num_ctx}[/bold]."
         )


### PR DESCRIPTION
## Description

This branch fixes the name of the locally created `ollama` model when adding a non-default context length