### PR TITLE
fix(ui): handling agent's undefined text in delta

### DIFF
--- a/apps/beeai-ui/src/modules/run/api/types.ts
+++ b/apps/beeai-ui/src/modules/run/api/types.ts
@@ -20,7 +20,8 @@ import { textOutputSchema } from '@i-am-bee/beeai-sdk/schemas/text';
 import { z } from 'zod';
 
 export const textNotificationSchema = AgentRunProgressNotificationSchema.extend({
-  params: z.object({ delta: textOutputSchema }),
+  // The text in delta should always be a string, but the agent could actually return undefined.
+  params: z.object({ delta: textOutputSchema.partial({ text: true }) }),
 });
 export type TextNotificationSchema = typeof textNotificationSchema;
 export type TextNotification = z.infer<TextNotificationSchema>;

--- a/apps/beeai-ui/src/modules/run/contexts/hands-off/HandsOffProvider.tsx
+++ b/apps/beeai-ui/src/modules/run/contexts/hands-off/HandsOffProvider.tsx
@@ -48,7 +48,7 @@ export function HandsOffProvider({ agent, children }: PropsWithChildren<Props>) 
       ...logs,
       ...logsDelta.filter((log): log is NonNullable<typeof log> => isNotNull(log) && log.message !== ''),
     ]);
-    setText((text) => text.concat(textDelta));
+    setText((text) => (textDelta ? text.concat(textDelta) : text));
   }, []);
 
   const handleCancel = useCallback(() => {


### PR DESCRIPTION
The text in delta should always be a string, but the agent could actually return undefined. This PR handles it.