### PR TITLE
fix(ui): space before BeeBadge

### DIFF
--- a/apps/beeai-ui/src/modules/agents/components/BeeBadge.module.scss
+++ b/apps/beeai-ui/src/modules/agents/components/BeeBadge.module.scss
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-.tag:global(.#{$prefix}--tag) {
+.container {
+  display: inline-block;
   margin-inline-start: $spacing-03;
 }
 

--- a/apps/beeai-ui/src/modules/agents/components/BeeBadge.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/BeeBadge.tsx
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { ComponentProps } from 'react';
+import type { ComponentProps } from 'react';
+import { Tag } from '@carbon/react';
 import { BEE_AI_FRAMEWORK_TAG } from '#utils/constants.ts';
 import { Tooltip } from '#components/Tooltip/Tooltip.tsx';
 import Bee from '#svgs/Bee.svg';
 import type { Agent } from '../api/types';
-import { Tag } from '@carbon/react';
 import classes from './BeeBadge.module.scss';
 
 interface Props {
@@ -33,7 +33,9 @@ export function BeeBadge({ agent, size }: Props) {
     <>
       {framework === BEE_AI_FRAMEWORK_TAG && (
         <Tooltip content="Built by the BeeAI team" placement="top" asChild>
-          <Tag type="green" renderIcon={Bee} size={size} className={classes.tag} />
+          <div className={classes.container}>
+            <Tag type="green" renderIcon={Bee} size={size} className={classes.tag} />
+          </div>
         </Tooltip>
       )}
     </>


### PR DESCRIPTION
Fixes spacing before the `<BeeBadge>` by placing it inside the container.

The conflicting style was:
https://github.com/carbon-design-system/carbon/blob/6ba85602a39e8247fc162902e8c0565e76b3496a/packages/styles/scss/components/tag/_tag.scss#L79-L81