### PR TITLE
fix(instrumentation): agent error and retry events

### DIFF
--- a/agents/official/agent-docs-creator/package-lock.json
+++ b/agents/official/agent-docs-creator/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai": "^1.1.13",
-        "@arizeai/openinference-instrumentation-beeai": "^1.1.2",
+        "@arizeai/openinference-instrumentation-beeai": "1.1.2",
         "@i-am-bee/acp-sdk": "0.0.5",
         "@i-am-bee/beeai-sdk": "0.0.16",
         "beeai-framework": "0.1.10",

--- a/agents/official/agent-docs-creator/package-lock.json
+++ b/agents/official/agent-docs-creator/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai": "^1.1.13",
-        "@arizeai/openinference-instrumentation-beeai": "^1.1.1",
+        "@arizeai/openinference-instrumentation-beeai": "^1.1.2",
         "@i-am-bee/acp-sdk": "0.0.5",
         "@i-am-bee/beeai-sdk": "0.0.16",
         "beeai-framework": "0.1.10",
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@arizeai/openinference-instrumentation-beeai": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@arizeai/openinference-instrumentation-beeai/-/openinference-instrumentation-beeai-1.1.1.tgz",
-      "integrity": "sha512-cPaUONze3m5V5uGivPUugECLkt12eBfhOHZukCO0+qEVVXrGOrGHmTpplsDcU1wGp7uwPskEwDqYIgYwTd0a0g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@arizeai/openinference-instrumentation-beeai/-/openinference-instrumentation-beeai-1.1.2.tgz",
+      "integrity": "sha512-y5rabFiZ6eMb47UKiqIvsGppcwVAW3x3i02bfD2p0Nk8vTtgbnCT7cEnukxRegbyxRaHPZf9759yVg7J8S/ImQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@arizeai/openinference-core": "1.0.0",

--- a/agents/official/agent-docs-creator/package.json
+++ b/agents/official/agent-docs-creator/package.json
@@ -15,7 +15,7 @@
   "description": "",
   "dependencies": {
     "@ai-sdk/openai": "^1.1.13",
-    "@arizeai/openinference-instrumentation-beeai": "^1.1.2",
+    "@arizeai/openinference-instrumentation-beeai": "1.1.2",
     "@i-am-bee/acp-sdk": "0.0.5",
     "@i-am-bee/beeai-sdk": "0.0.16",
     "beeai-framework": "0.1.10",

--- a/agents/official/agent-docs-creator/package.json
+++ b/agents/official/agent-docs-creator/package.json
@@ -15,7 +15,7 @@
   "description": "",
   "dependencies": {
     "@ai-sdk/openai": "^1.1.13",
-    "@arizeai/openinference-instrumentation-beeai": "^1.1.1",
+    "@arizeai/openinference-instrumentation-beeai": "^1.1.2",
     "@i-am-bee/acp-sdk": "0.0.5",
     "@i-am-bee/beeai-sdk": "0.0.16",
     "beeai-framework": "0.1.10",

--- a/agents/official/beeai-framework/package-lock.json
+++ b/agents/official/beeai-framework/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai": "^1.1.14",
-        "@arizeai/openinference-instrumentation-beeai": "^1.1.2",
+        "@arizeai/openinference-instrumentation-beeai": "1.1.2",
         "@i-am-bee/acp-sdk": "0.0.5",
         "@i-am-bee/beeai-sdk": "0.0.16",
         "beeai-framework": "0.1.10",

--- a/agents/official/beeai-framework/package-lock.json
+++ b/agents/official/beeai-framework/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai": "^1.1.14",
-        "@arizeai/openinference-instrumentation-beeai": "^1.1.1",
+        "@arizeai/openinference-instrumentation-beeai": "^1.1.2",
         "@i-am-bee/acp-sdk": "0.0.5",
         "@i-am-bee/beeai-sdk": "0.0.16",
         "beeai-framework": "0.1.10",
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@arizeai/openinference-instrumentation-beeai": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@arizeai/openinference-instrumentation-beeai/-/openinference-instrumentation-beeai-1.1.1.tgz",
-      "integrity": "sha512-cPaUONze3m5V5uGivPUugECLkt12eBfhOHZukCO0+qEVVXrGOrGHmTpplsDcU1wGp7uwPskEwDqYIgYwTd0a0g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@arizeai/openinference-instrumentation-beeai/-/openinference-instrumentation-beeai-1.1.2.tgz",
+      "integrity": "sha512-y5rabFiZ6eMb47UKiqIvsGppcwVAW3x3i02bfD2p0Nk8vTtgbnCT7cEnukxRegbyxRaHPZf9759yVg7J8S/ImQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@arizeai/openinference-core": "1.0.0",

--- a/agents/official/beeai-framework/package.json
+++ b/agents/official/beeai-framework/package.json
@@ -14,7 +14,7 @@
   "description": "",
   "dependencies": {
     "@ai-sdk/openai": "^1.1.14",
-    "@arizeai/openinference-instrumentation-beeai": "^1.1.2",
+    "@arizeai/openinference-instrumentation-beeai": "1.1.2",
     "@i-am-bee/acp-sdk": "0.0.5",
     "@i-am-bee/beeai-sdk": "0.0.16",
     "beeai-framework": "0.1.10",

--- a/agents/official/beeai-framework/package.json
+++ b/agents/official/beeai-framework/package.json
@@ -14,7 +14,7 @@
   "description": "",
   "dependencies": {
     "@ai-sdk/openai": "^1.1.14",
-    "@arizeai/openinference-instrumentation-beeai": "^1.1.1",
+    "@arizeai/openinference-instrumentation-beeai": "^1.1.2",
     "@i-am-bee/acp-sdk": "0.0.5",
     "@i-am-bee/beeai-sdk": "0.0.16",
     "beeai-framework": "0.1.10",


### PR DESCRIPTION
I badly parsed the memory object on agent's error/retry events. This error is fixed in the latest package version. 
See https://github.com/Arize-ai/openinference/blob/main/js/packages/openinference-instrumentation-beeai/CHANGELOG.md#patch-changes