### PR TITLE
chore(ui): add eslint plugin to sort imports

### DIFF
--- a/apps/beeai-ui/eslint.config.js
+++ b/apps/beeai-ui/eslint.config.js
@@ -1,6 +1,7 @@
 import js from '@eslint/js';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
+import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
@@ -16,12 +17,15 @@ export default tseslint.config(
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
+      'simple-import-sort': simpleImportSort,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/no-import-type-side-effects': 'error',
+      'simple-import-sort/imports': 'error',
+      'simple-import-sort/exports': 'error',
     },
   },
 );

--- a/apps/beeai-ui/package.json
+++ b/apps/beeai-ui/package.json
@@ -76,6 +76,7 @@
     "eslint": "catalog:",
     "eslint-plugin-react-hooks": "catalog:",
     "eslint-plugin-react-refresh": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "globals": "catalog:",
     "keycode-js": "^3.1.0",
     "prettier": "catalog:",

--- a/apps/beeai-ui/src/App.tsx
+++ b/apps/beeai-ui/src/App.tsx
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { ErrorBoundary } from 'react-error-boundary';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
+
 import { ErrorFallback } from '#components/fallbacks/ErrorFallback.tsx';
 import { AppLayout } from '#components/layouts/AppLayout.tsx';
 import { MCPClientProvider } from '#contexts/MCPClient/MCPClientProvider.tsx';
@@ -29,8 +32,6 @@ import { NotFound } from '#pages/NotFound.tsx';
 import { AgentRunPage } from '#pages/run/AgentRunPage.tsx';
 import { Settings } from '#pages/Settings.tsx';
 import { routeDefinitions } from '#utils/router.ts';
-import { ErrorBoundary } from 'react-error-boundary';
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
 
 export function App() {
   return (

--- a/apps/beeai-ui/src/api/index.ts
+++ b/apps/beeai-ui/src/api/index.ts
@@ -15,6 +15,7 @@
  */
 
 import createClient from 'openapi-fetch';
+
 import type { paths } from './schema';
 
 export const api = createClient<paths>({

--- a/apps/beeai-ui/src/api/mcp-client/useCreateMCPClient.ts
+++ b/apps/beeai-ui/src/api/mcp-client/useCreateMCPClient.ts
@@ -17,6 +17,7 @@
 import { Client as MCPClient } from '@i-am-bee/acp-sdk/client/index';
 import { SSEClientTransport } from '@i-am-bee/acp-sdk/client/sse';
 import { useCallback, useEffect, useRef, useState } from 'react';
+
 import { ClientStatus } from './types';
 
 /**

--- a/apps/beeai-ui/src/components/AnimateHeightChange/AnimateHeightChange.tsx
+++ b/apps/beeai-ui/src/components/AnimateHeightChange/AnimateHeightChange.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import { parseCarbonMotion } from '#utils/fadeProps.ts';
-import { motion as carbonMotion, moderate02 } from '@carbon/motion';
+import { moderate02, motion as carbonMotion } from '@carbon/motion';
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
 import type { PropsWithChildren } from 'react';
 import { useEffect, useRef, useState } from 'react';
+
+import { parseCarbonMotion } from '#utils/fadeProps.ts';
+
 import classes from './AnimateHeightChange.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/components/CommunityNav/CommunityNav.tsx
+++ b/apps/beeai-ui/src/components/CommunityNav/CommunityNav.tsx
@@ -15,8 +15,10 @@
  */
 
 import { LogoDiscord, LogoYoutube } from '@carbon/icons-react';
+
 import LogoBluesky from '#svgs/LogoBluesky.svg';
-import { DISCORD_LINK, YOUTUBE_LINK, BLUESKY_LINK } from '#utils/constants.ts';
+import { BLUESKY_LINK, DISCORD_LINK, YOUTUBE_LINK } from '#utils/constants.ts';
+
 import classes from './CommunityNav.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/apps/beeai-ui/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import type { ModalProps } from '#contexts/Modal/modal-context.ts';
 import { Button, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
 import { TrashCan } from '@carbon/react/icons';
 import clsx from 'clsx';
 import type { ComponentType, ReactNode } from 'react';
+
+import type { ModalProps } from '#contexts/Modal/modal-context.ts';
+
 import { Modal } from '../Modal/Modal';
 import classes from './ConfirmDialog.module.scss';
 

--- a/apps/beeai-ui/src/components/CopySnippet/CopySnippet.tsx
+++ b/apps/beeai-ui/src/components/CopySnippet/CopySnippet.tsx
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { type ReactElement, useState, useRef } from 'react';
-import { IconButton } from '@carbon/react';
 import { Checkmark, Copy } from '@carbon/icons-react';
+import { IconButton } from '@carbon/react';
 import clsx from 'clsx';
+import { type ReactElement, useRef, useState } from 'react';
+
 import classes from './CopySnippet.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/apps/beeai-ui/src/components/ErrorMessage/ErrorMessage.tsx
@@ -16,6 +16,7 @@
 
 import { ActionableNotification, Button, InlineLoading } from '@carbon/react';
 import type { ReactNode } from 'react';
+
 import classes from './ErrorMessage.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/components/ErrorPage/ErrorPage.tsx
+++ b/apps/beeai-ui/src/components/ErrorPage/ErrorPage.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import NotFound from '#svgs/NotFound.svg';
-import { routes } from '#utils/router.ts';
 import { ArrowRight } from '@carbon/icons-react';
 import { Button } from '@carbon/react';
+
+import NotFound from '#svgs/NotFound.svg';
+import { routes } from '#utils/router.ts';
+
 import { Container } from '../layouts/Container';
 import { TransitionLink } from '../TransitionLink/TransitionLink';
 import classes from './ErrorPage.module.scss';

--- a/apps/beeai-ui/src/components/ExpandButton/ExpandButton.tsx
+++ b/apps/beeai-ui/src/components/ExpandButton/ExpandButton.tsx
@@ -17,6 +17,7 @@
 import { ChevronDown } from '@carbon/icons-react';
 import type { ButtonBaseProps } from '@carbon/react';
 import { Button } from '@carbon/react';
+
 import classes from './ExpandButton.module.scss';
 
 export function ExpandButton({ children, ...props }: Omit<ButtonBaseProps, 'ghost' | 'className'>) {

--- a/apps/beeai-ui/src/components/FiltersPopover/FiltersPopover.tsx
+++ b/apps/beeai-ui/src/components/FiltersPopover/FiltersPopover.tsx
@@ -16,9 +16,10 @@
 
 'use client';
 
-import { useState } from 'react';
-import { Popover, PopoverContent, Button, Link, CheckboxGroup, Checkbox } from '@carbon/react';
 import { Filter } from '@carbon/icons-react';
+import { Button, Checkbox, CheckboxGroup, Link, Popover, PopoverContent } from '@carbon/react';
+import { useState } from 'react';
+
 import classes from './FiltersPopover.module.scss';
 
 interface Option {

--- a/apps/beeai-ui/src/components/GitHubLink/GitHubLink.tsx
+++ b/apps/beeai-ui/src/components/GitHubLink/GitHubLink.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { GITHUB_REPO_LINK } from '#utils/constants.ts';
 import { LogoGithub } from '@carbon/icons-react';
+
+import { GITHUB_REPO_LINK } from '#utils/constants.ts';
+
 import classes from './GitHubLink.module.scss';
 
 export function GitHubLink() {

--- a/apps/beeai-ui/src/components/LineClampText/LineClampText.tsx
+++ b/apps/beeai-ui/src/components/LineClampText/LineClampText.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import { ExpandButton } from '#components/ExpandButton/ExpandButton.tsx';
 import clsx from 'clsx';
 import type { CSSProperties, PropsWithChildren } from 'react';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { useDebounceCallback } from 'usehooks-ts';
+
+import { ExpandButton } from '#components/ExpandButton/ExpandButton.tsx';
+
 import classes from './LineClampText.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/components/MainContentView/MainContentView.tsx
+++ b/apps/beeai-ui/src/components/MainContentView/MainContentView.tsx
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
+import clsx from 'clsx';
+import type { PropsWithChildren } from 'react';
+import { mergeRefs } from 'react-merge-refs';
+
 import { AppFooter } from '#components/layouts/AppFooter.tsx';
 import { useScrollbarWidth } from '#hooks/useScrollbarWidth.ts';
 import { useToTopButton } from '#hooks/useToTopButton.ts';
 import { createScrollbarStyles } from '#utils/createScrollbarStyles.ts';
-import clsx from 'clsx';
-import type { PropsWithChildren } from 'react';
-import { mergeRefs } from 'react-merge-refs';
+
 import { ToTopButton } from '../ToTopButton/ToTopButton';
 import classes from './MainContentView.module.scss';
 

--- a/apps/beeai-ui/src/components/MainNav/MainNav.tsx
+++ b/apps/beeai-ui/src/components/MainNav/MainNav.tsx
@@ -16,11 +16,13 @@
 
 'use client';
 
-import { Tooltip } from '#components/Tooltip/Tooltip.tsx';
 import type { CarbonIconType } from '@carbon/icons-react';
 import { Button } from '@carbon/react';
 import clsx from 'clsx';
 import type { ComponentType, ReactNode } from 'react';
+
+import { Tooltip } from '#components/Tooltip/Tooltip.tsx';
+
 import classes from './MainNav.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/components/MarkdownContent/MarkdownContent.tsx
+++ b/apps/beeai-ui/src/components/MarkdownContent/MarkdownContent.tsx
@@ -16,6 +16,7 @@
 
 import clsx from 'clsx';
 import Markdown from 'react-markdown';
+
 import { components } from './components';
 import classes from './MarkdownContent.module.scss';
 

--- a/apps/beeai-ui/src/components/MarkdownContent/components/code.tsx
+++ b/apps/beeai-ui/src/components/MarkdownContent/components/code.tsx
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import type { Components } from 'react-markdown';
 import { isString } from 'lodash';
+import type { Components } from 'react-markdown';
+
 import { CopySnippet } from '#components/CopySnippet/CopySnippet.tsx';
 import { SyntaxHighlighter } from '#components/SyntaxHighlighter/SyntaxHighlighter.tsx';
 

--- a/apps/beeai-ui/src/components/MarkdownContent/components/index.ts
+++ b/apps/beeai-ui/src/components/MarkdownContent/components/index.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Components } from 'react-markdown';
+
 import { code } from './code';
 
 export const components: Components = {

--- a/apps/beeai-ui/src/components/Modal/Modal.tsx
+++ b/apps/beeai-ui/src/components/Modal/Modal.tsx
@@ -20,6 +20,7 @@ import clsx from 'clsx';
 import { AnimatePresence, motion } from 'framer-motion';
 import type { HTMLAttributes, KeyboardEventHandler, ReactNode } from 'react';
 import { useEffect, useId, useRef, useState } from 'react';
+
 import classes from './Modal.module.scss';
 
 type Props = {

--- a/apps/beeai-ui/src/components/Spinner/Spinner.tsx
+++ b/apps/beeai-ui/src/components/Spinner/Spinner.tsx
@@ -16,6 +16,7 @@
 
 import clsx from 'clsx';
 import { lazy } from 'react';
+
 import SpinnerAnimation from './BouncingDotsAnimation.json';
 import classes from './Spinner.module.scss';
 

--- a/apps/beeai-ui/src/components/SplitPanesView/SplitPanesView.tsx
+++ b/apps/beeai-ui/src/components/SplitPanesView/SplitPanesView.tsx
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
+import { moderate02 } from '@carbon/motion';
+import { AnimatePresence, motion } from 'framer-motion';
+import type { PropsWithChildren, ReactNode } from 'react';
+
 import { Container } from '#components/layouts/Container.tsx';
 import { MainContent } from '#components/layouts/MainContent.tsx';
 import type { MainContentViewProps } from '#components/MainContentView/MainContentView.tsx';
 import { useScrollbarWidth } from '#hooks/useScrollbarWidth.ts';
 import { createScrollbarStyles } from '#utils/createScrollbarStyles.ts';
-import { moderate02 } from '@carbon/motion';
-import { AnimatePresence, motion } from 'framer-motion';
-import type { PropsWithChildren, ReactNode } from 'react';
+
 import classes from './SplitPanesView.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
+++ b/apps/beeai-ui/src/components/SyntaxHighlighter/SyntaxHighlighter.tsx
@@ -15,9 +15,10 @@
  */
 
 import { Light as Highlighter } from 'react-syntax-highlighter';
-import { style, customStyle } from './theme';
+
 import { registerLanguages } from './languages';
 import classes from './SyntaxHighlighter.module.scss';
+import { customStyle, style } from './theme';
 
 interface Props {
   language: string;

--- a/apps/beeai-ui/src/components/SyntaxHighlighter/languages.ts
+++ b/apps/beeai-ui/src/components/SyntaxHighlighter/languages.ts
@@ -15,12 +15,12 @@
  */
 
 import bash from 'react-syntax-highlighter/dist/esm/languages/hljs/bash';
-import shell from 'react-syntax-highlighter/dist/esm/languages/hljs/shell';
-import json from 'react-syntax-highlighter/dist/esm/languages/hljs/json';
-import yaml from 'react-syntax-highlighter/dist/esm/languages/hljs/yaml';
 import javascript from 'react-syntax-highlighter/dist/esm/languages/hljs/javascript';
-import typescript from 'react-syntax-highlighter/dist/esm/languages/hljs/typescript';
+import json from 'react-syntax-highlighter/dist/esm/languages/hljs/json';
 import python from 'react-syntax-highlighter/dist/esm/languages/hljs/python';
+import shell from 'react-syntax-highlighter/dist/esm/languages/hljs/shell';
+import typescript from 'react-syntax-highlighter/dist/esm/languages/hljs/typescript';
+import yaml from 'react-syntax-highlighter/dist/esm/languages/hljs/yaml';
 
 export function registerLanguages<Highlighter extends { registerLanguage(name: string, func: unknown): void }>(
   highlighter: Highlighter,

--- a/apps/beeai-ui/src/components/TableView/TableView.tsx
+++ b/apps/beeai-ui/src/components/TableView/TableView.tsx
@@ -15,6 +15,7 @@
  */
 
 import type { PropsWithChildren } from 'react';
+
 import classes from './TableView.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/components/TableView/TableViewActions.tsx
+++ b/apps/beeai-ui/src/components/TableView/TableViewActions.tsx
@@ -15,6 +15,7 @@
  */
 
 import type { PropsWithChildren } from 'react';
+
 import classes from './TableViewActions.module.scss';
 
 export function TableViewActions({ children }: PropsWithChildren) {

--- a/apps/beeai-ui/src/components/TableView/TableViewToolbar.tsx
+++ b/apps/beeai-ui/src/components/TableView/TableViewToolbar.tsx
@@ -19,6 +19,7 @@ import type { TextInputProps } from '@carbon/react';
 import { TextInput } from '@carbon/react';
 import type { ReactNode } from 'react';
 import { useId } from 'react';
+
 import classes from './TableViewToolbar.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/components/TagsList/TagsList.tsx
+++ b/apps/beeai-ui/src/components/TagsList/TagsList.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import { SkeletonItems } from '#components/SkeletonItems/SkeletonItems.tsx';
 import { TagSkeleton } from '@carbon/react';
 import clsx from 'clsx';
 import type { ReactElement } from 'react';
+
+import { SkeletonItems } from '#components/SkeletonItems/SkeletonItems.tsx';
+
 import classes from './TagsList.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/components/TextAreaAutoHeight/TextAreaAutoHeight.tsx
+++ b/apps/beeai-ui/src/components/TextAreaAutoHeight/TextAreaAutoHeight.tsx
@@ -15,11 +15,12 @@
  */
 
 import clsx from 'clsx';
-import type { CSSProperties, ChangeEvent, TextareaHTMLAttributes } from 'react';
+import type { ChangeEvent, CSSProperties, TextareaHTMLAttributes } from 'react';
 import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { mergeRefs } from 'react-merge-refs';
-import classes from './TextAreaAutoHeight.module.scss';
 import { Resizable } from 'react-resizable';
+
+import classes from './TextAreaAutoHeight.module.scss';
 
 type Props = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'value'> & {
   maxRows?: number;

--- a/apps/beeai-ui/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/apps/beeai-ui/src/components/ThemeToggle/ThemeToggle.tsx
@@ -16,11 +16,13 @@
 
 'use client';
 
-import { useTheme } from '#contexts/Theme/index.ts';
-import { Theme } from '#contexts/Theme/types.ts';
 import { Asleep, Awake } from '@carbon/icons-react';
 import { IconButton } from '@carbon/react';
 import { useEffect, useState } from 'react';
+
+import { useTheme } from '#contexts/Theme/index.ts';
+import { Theme } from '#contexts/Theme/types.ts';
+
 import classes from './ThemeToggle.module.scss';
 
 export function ThemeToggle() {

--- a/apps/beeai-ui/src/components/ToTopButton/ToTopButton.tsx
+++ b/apps/beeai-ui/src/components/ToTopButton/ToTopButton.tsx
@@ -19,6 +19,7 @@
 import { ArrowUp } from '@carbon/icons-react';
 import type { IconButtonProps } from '@carbon/react';
 import { IconButton } from '@carbon/react';
+
 import classes from './ToTopButton.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/components/Tooltip/Tooltip.tsx
+++ b/apps/beeai-ui/src/components/Tooltip/Tooltip.tsx
@@ -35,6 +35,7 @@ import { Slot } from '@radix-ui/react-slot';
 import clsx from 'clsx';
 import type { PropsWithChildren, ReactNode } from 'react';
 import { useRef, useState } from 'react';
+
 import classes from './Tooltip.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/components/TransitionLink/TransitionLink.tsx
+++ b/apps/beeai-ui/src/components/TransitionLink/TransitionLink.tsx
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { useViewTransition } from '#hooks/useViewTransition.ts';
 import { Slot } from '@radix-ui/react-slot';
 import type { HTMLProps } from 'react';
+
+import { useViewTransition } from '#hooks/useViewTransition.ts';
 
 interface Props extends Omit<HTMLProps<HTMLAnchorElement>, 'href'> {
   href?: string;

--- a/apps/beeai-ui/src/components/TryLocallyButton/TryLocallyButton.tsx
+++ b/apps/beeai-ui/src/components/TryLocallyButton/TryLocallyButton.tsx
@@ -16,9 +16,11 @@
 
 'use client';
 
-import { TRY_LOCALLY_LINK } from '#utils/constants.ts';
 import { ArrowUpRight } from '@carbon/icons-react';
 import { Button } from '@carbon/react';
+
+import { TRY_LOCALLY_LINK } from '#utils/constants.ts';
+
 import classes from './TryLocallyButton.module.scss';
 
 export function TryLocallyButton() {

--- a/apps/beeai-ui/src/components/UserNav/UserNav.tsx
+++ b/apps/beeai-ui/src/components/UserNav/UserNav.tsx
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
+import { ArrowUpRight, Asleep, Awake, LogoDiscord, LogoGithub, LogoYoutube, Settings } from '@carbon/icons-react';
+import { OverflowMenu, OverflowMenuItem } from '@carbon/react';
+import { useMemo } from 'react';
+
 import { useTheme } from '#contexts/Theme/index.ts';
 import { Theme } from '#contexts/Theme/types.ts';
 import { useViewTransition } from '#hooks/useViewTransition.ts';
 import LogoBluesky from '#svgs/LogoBluesky.svg';
 import { BLUESKY_LINK, DISCORD_LINK, DOCUMENTATION_LINK, GITHUB_REPO_LINK, YOUTUBE_LINK } from '#utils/constants.ts';
 import { routes } from '#utils/router.ts';
-import { ArrowUpRight, Asleep, Awake, LogoDiscord, LogoGithub, LogoYoutube, Settings } from '@carbon/icons-react';
-import { OverflowMenu, OverflowMenuItem } from '@carbon/react';
-import { useMemo } from 'react';
+
 import classes from './UserNav.module.scss';
 
 export function UserNav() {

--- a/apps/beeai-ui/src/components/VersionTag/VersionTag.tsx
+++ b/apps/beeai-ui/src/components/VersionTag/VersionTag.tsx
@@ -15,8 +15,9 @@
  */
 
 import { Tag } from '@carbon/react';
-import classes from './VersionTag.module.scss';
 import type { ComponentProps, PropsWithChildren } from 'react';
+
+import classes from './VersionTag.module.scss';
 
 type Props = ComponentProps<typeof Tag>;
 

--- a/apps/beeai-ui/src/components/ViewHeader/ViewHeader.tsx
+++ b/apps/beeai-ui/src/components/ViewHeader/ViewHeader.tsx
@@ -15,6 +15,7 @@
  */
 
 import type { PropsWithChildren, ReactElement } from 'react';
+
 import classes from './ViewHeader.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/components/ViewStack/ViewStack.tsx
+++ b/apps/beeai-ui/src/components/ViewStack/ViewStack.tsx
@@ -15,6 +15,7 @@
  */
 
 import type { PropsWithChildren } from 'react';
+
 import classes from './ViewStack.module.scss';
 
 export function ViewStack({ children }: PropsWithChildren) {

--- a/apps/beeai-ui/src/components/fallbacks/ErrorFallback.tsx
+++ b/apps/beeai-ui/src/components/fallbacks/ErrorFallback.tsx
@@ -15,6 +15,7 @@
  */
 
 import type { FallbackProps } from 'react-error-boundary';
+
 import { ErrorLayout } from '../layouts/ErrorLayout';
 
 export function ErrorFallback({ error }: FallbackProps) {

--- a/apps/beeai-ui/src/components/fallbacks/ModalFallback.tsx
+++ b/apps/beeai-ui/src/components/fallbacks/ModalFallback.tsx
@@ -16,8 +16,10 @@
 
 import { ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
 import type { FallbackProps } from 'react-error-boundary';
-import { Modal } from '../Modal/Modal';
+
 import type { ModalProps } from '#contexts/Modal/modal-context.ts';
+
+import { Modal } from '../Modal/Modal';
 
 interface Props extends FallbackProps, ModalProps {}
 

--- a/apps/beeai-ui/src/components/layouts/AppHeader.tsx
+++ b/apps/beeai-ui/src/components/layouts/AppHeader.tsx
@@ -16,6 +16,7 @@
 
 import clsx from 'clsx';
 import type { PropsWithChildren } from 'react';
+
 import classes from './AppHeader.module.scss';
 import { Container } from './Container';
 

--- a/apps/beeai-ui/src/components/layouts/AppLayout.tsx
+++ b/apps/beeai-ui/src/components/layouts/AppLayout.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { UserNav } from '#components/UserNav/UserNav.tsx';
 import { Outlet } from 'react-router';
+
+import { UserNav } from '#components/UserNav/UserNav.tsx';
+
 import { AppHeader } from './AppHeader';
 import classes from './AppLayout.module.scss';
 import { Navigation } from './Navigation';

--- a/apps/beeai-ui/src/components/layouts/Container.tsx
+++ b/apps/beeai-ui/src/components/layouts/Container.tsx
@@ -16,6 +16,7 @@
 
 import clsx from 'clsx';
 import type { PropsWithChildren } from 'react';
+
 import classes from './Container.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/components/layouts/ErrorLayout.tsx
+++ b/apps/beeai-ui/src/components/layouts/ErrorLayout.tsx
@@ -15,6 +15,7 @@
  */
 
 import type { PropsWithChildren } from 'react';
+
 import { Container } from './Container';
 import classes from './ErrorLayout.module.scss';
 

--- a/apps/beeai-ui/src/components/layouts/MainContent.tsx
+++ b/apps/beeai-ui/src/components/layouts/MainContent.tsx
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
+import { useLocation } from 'react-router';
+
 import type { MainContentViewProps } from '#components/MainContentView/MainContentView.tsx';
 import { MainContentView } from '#components/MainContentView/MainContentView.tsx';
 import { routes } from '#utils/router.ts';
-import { useLocation } from 'react-router';
 
 export function MainContent({ ...props }: MainContentViewProps) {
   const { pathname } = useLocation();

--- a/apps/beeai-ui/src/components/layouts/Navigation.tsx
+++ b/apps/beeai-ui/src/components/layouts/Navigation.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { useMemo } from 'react';
+
 import { MainNav } from '#components/MainNav/MainNav.tsx';
 import { TracesTooltip } from '#components/MainNav/TracesTooltip.tsx';
 import { TransitionLink } from '#components/TransitionLink/TransitionLink.tsx';
@@ -21,7 +23,6 @@ import { useIsNavSectionActive } from '#hooks/useIsNavSectionActive.ts';
 import { usePhoenix } from '#modules/phoenix/api/queries/usePhoenix.ts';
 import { routes, sections } from '#utils/router.ts';
 import { APP_NAME, PHOENIX_SERVER_TARGET } from '#utils/vite-constants.ts';
-import { useMemo } from 'react';
 
 export function Navigation() {
   const isSectionActive = useIsNavSectionActive();

--- a/apps/beeai-ui/src/contexts/MCPClient/MCPClientProvider.tsx
+++ b/apps/beeai-ui/src/contexts/MCPClient/MCPClientProvider.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import { useCreateMCPClient } from '#api/mcp-client/useCreateMCPClient.ts';
 import { useQueryClient } from '@tanstack/react-query';
 import type { PropsWithChildren } from 'react';
 import { useEffect } from 'react';
+
+import { useCreateMCPClient } from '#api/mcp-client/useCreateMCPClient.ts';
+
 import { MCPClientContext } from './mcp-client-context';
 
 export function MCPClientProvider({ children }: PropsWithChildren) {

--- a/apps/beeai-ui/src/contexts/MCPClient/index.ts
+++ b/apps/beeai-ui/src/contexts/MCPClient/index.ts
@@ -15,6 +15,7 @@
  */
 
 import { use } from 'react';
+
 import { MCPClientContext } from './mcp-client-context';
 
 export function useMCPClient() {

--- a/apps/beeai-ui/src/contexts/Modal/ModalProvider.tsx
+++ b/apps/beeai-ui/src/contexts/Modal/ModalProvider.tsx
@@ -18,9 +18,11 @@ import type { PropsWithChildren } from 'react';
 import { memo, useCallback, useLayoutEffect, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { v4 as uuid } from 'uuid';
+
+import { FallbackModal } from '#components/fallbacks/ModalFallback.tsx';
+
 import type { ModalState, OpenModalFn } from './modal-context';
 import { ModalContext } from './modal-context';
-import { FallbackModal } from '#components/fallbacks/ModalFallback.tsx';
 
 export function ModalProvider({ children }: PropsWithChildren) {
   const [modals, setModals] = useState<Record<string, ModalState>>(Object.create(null));

--- a/apps/beeai-ui/src/contexts/Modal/index.tsx
+++ b/apps/beeai-ui/src/contexts/Modal/index.tsx
@@ -15,9 +15,11 @@
  */
 
 import { useCallback, useContext } from 'react';
-import { ModalContext } from './modal-context';
+
 import type { ConfirmDialogProps } from '#components/ConfirmDialog/ConfirmDialog.tsx';
 import { ConfirmDialog } from '#components/ConfirmDialog/ConfirmDialog.tsx';
+
+import { ModalContext } from './modal-context';
 
 export function useModal() {
   const openModal = useContext(ModalContext);

--- a/apps/beeai-ui/src/contexts/Modal/modal-context.ts
+++ b/apps/beeai-ui/src/contexts/Modal/modal-context.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { noop } from '#utils/helpers.ts';
 import type { ReactNode } from 'react';
 import { createContext } from 'react';
+
+import { noop } from '#utils/helpers.ts';
 
 export interface ModalProps {
   /** True if modal is open */

--- a/apps/beeai-ui/src/contexts/QueryProvider/QueryProvider.tsx
+++ b/apps/beeai-ui/src/contexts/QueryProvider/QueryProvider.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import type { PropsWithChildren } from 'react';
 import { matchQuery, MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PropsWithChildren } from 'react';
+
 import { useHandleError } from '#hooks/useHandleError.ts';
+
 import type { HandleError } from './types';
 
 const createQueryClient = ({ handleError }: { handleError: HandleError }) => {

--- a/apps/beeai-ui/src/contexts/QueryProvider/types.ts
+++ b/apps/beeai-ui/src/contexts/QueryProvider/types.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import type { useHandleError } from '#hooks/useHandleError.ts';
 import type { QueryKey } from '@tanstack/react-query';
+
+import type { useHandleError } from '#hooks/useHandleError.ts';
 
 export interface QueryMetadata extends Record<string, unknown> {
   errorToast?:

--- a/apps/beeai-ui/src/contexts/Theme/ThemeProvider.tsx
+++ b/apps/beeai-ui/src/contexts/Theme/ThemeProvider.tsx
@@ -19,6 +19,7 @@
 import type { PropsWithChildren } from 'react';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useLocalStorage, useMediaQuery } from 'usehooks-ts';
+
 import { ThemeContext } from './theme-context';
 import { Theme } from './types';
 import { getThemeClassName } from './utils';

--- a/apps/beeai-ui/src/contexts/Theme/index.ts
+++ b/apps/beeai-ui/src/contexts/Theme/index.ts
@@ -15,6 +15,7 @@
  */
 
 import { use } from 'react';
+
 import { ThemeContext } from './theme-context';
 
 export function useTheme() {

--- a/apps/beeai-ui/src/contexts/Theme/theme-context.ts
+++ b/apps/beeai-ui/src/contexts/Theme/theme-context.ts
@@ -15,6 +15,7 @@
  */
 
 import { createContext } from 'react';
+
 import type { Theme } from './types';
 
 export const ThemeContext = createContext<ThemeContextValue>({} as ThemeContextValue);

--- a/apps/beeai-ui/src/contexts/Toast/ToastProvider.tsx
+++ b/apps/beeai-ui/src/contexts/Toast/ToastProvider.tsx
@@ -19,9 +19,10 @@ import clsx from 'clsx';
 import type { PropsWithChildren } from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { v4 as uuid } from 'uuid';
-import classes from './ToastProvider.module.scss';
+
 import type { Toast, ToastWithKey } from './toast-context';
 import { ToastContext } from './toast-context';
+import classes from './ToastProvider.module.scss';
 
 export function ToastProvider({ children }: PropsWithChildren) {
   const [toasts, setToasts] = useState<ToastWithKey[]>([]);

--- a/apps/beeai-ui/src/contexts/Toast/index.ts
+++ b/apps/beeai-ui/src/contexts/Toast/index.ts
@@ -15,6 +15,7 @@
  */
 
 import { use } from 'react';
+
 import { ToastContext } from './toast-context';
 
 export function useToast() {

--- a/apps/beeai-ui/src/hooks/useAutoScroll.ts
+++ b/apps/beeai-ui/src/hooks/useAutoScroll.ts
@@ -15,6 +15,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+
 import { useScrollableContainer } from './useScrollableContainer';
 
 export function useAutoScroll(dependencies: unknown[]) {

--- a/apps/beeai-ui/src/hooks/useHandleError.ts
+++ b/apps/beeai-ui/src/hooks/useHandleError.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import { useCallback } from 'react';
+
 import type { QueryMetadata } from '#contexts/QueryProvider/types.ts';
 import { useToast } from '#contexts/Toast/index.ts';
-import { useCallback } from 'react';
 
 export function useHandleError() {
   const { addToast } = useToast();

--- a/apps/beeai-ui/src/hooks/useImmerWithGetter.ts
+++ b/apps/beeai-ui/src/hooks/useImmerWithGetter.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { useMemo, useRef, useState } from 'react';
 import type { Draft } from 'immer';
 import { produce } from 'immer';
+import { useMemo, useRef, useState } from 'react';
 
 export type DraftFunction<S> = (draft: Draft<S>) => void;
 export type Updater<S> = (arg: S | DraftFunction<S>) => void;

--- a/apps/beeai-ui/src/hooks/useIsNavSectionActive.ts
+++ b/apps/beeai-ui/src/hooks/useIsNavSectionActive.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import type { NavSectionName } from '#utils/router.ts';
 import { useCallback } from 'react';
 import { useLocation } from 'react-router';
+
+import type { NavSectionName } from '#utils/router.ts';
 
 export function useIsNavSectionActive() {
   const { pathname } = useLocation();

--- a/apps/beeai-ui/src/hooks/useToTopButton.ts
+++ b/apps/beeai-ui/src/hooks/useToTopButton.ts
@@ -16,8 +16,9 @@
 
 'use client';
 
-import { noop } from '#utils/helpers.ts';
 import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { noop } from '#utils/helpers.ts';
 
 interface Props {
   enabled?: boolean;

--- a/apps/beeai-ui/src/index.ts
+++ b/apps/beeai-ui/src/index.ts
@@ -14,29 +14,24 @@
  * limitations under the License.
  */
 
-export * from './utils/constants';
-
-export * from './contexts/Theme/ThemeProvider';
-
 export * from './components/CommunityNav/CommunityNav';
 export * from './components/GitHubLink/GitHubLink';
 export * from './components/layouts/AppFooter';
 export * from './components/layouts/AppHeader';
 export * from './components/layouts/Container';
+export type * from './components/MainContentView/MainContentView';
 export * from './components/MainContentView/MainContentView';
 export * from './components/MainNav/MainNav';
 export * from './components/ToTopButton/ToTopButton';
 export * from './components/TryLocallyButton/TryLocallyButton';
 export * from './components/ViewStack/ViewStack';
-
-export * from './modules/home/components/GettingStarted';
-
+export * from './contexts/Theme/ThemeProvider';
 export * from './modules/agents/api/types';
 export * from './modules/agents/components/AgentCard';
 export * from './modules/agents/components/AgentDetail';
 export * from './modules/agents/components/AgentsFilters';
 export * from './modules/agents/components/AgentsList';
 export * from './modules/agents/providers/AgentsFiltersProvider';
-
-export type * from './components/MainContentView/MainContentView';
+export * from './modules/home/components/GettingStarted';
 export type * from './modules/home/components/VideoBeeAI';
+export * from './utils/constants';

--- a/apps/beeai-ui/src/main.tsx
+++ b/apps/beeai-ui/src/main.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import './styles/style.scss';
+
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import './styles/style.scss';
+
 // Needs to be after style.scss
 import { App } from './App';
 

--- a/apps/beeai-ui/src/modules/agents/api/queries/useAgent.ts
+++ b/apps/beeai-ui/src/modules/agents/api/queries/useAgent.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { useMCPClient } from '#contexts/MCPClient/index.ts';
 import { useQuery } from '@tanstack/react-query';
+
+import { useMCPClient } from '#contexts/MCPClient/index.ts';
+
 import { agentKeys } from '../keys';
 import type { Agent } from '../types';
 

--- a/apps/beeai-ui/src/modules/agents/api/queries/useListAgents.ts
+++ b/apps/beeai-ui/src/modules/agents/api/queries/useListAgents.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { useMCPClient } from '#contexts/MCPClient/index.ts';
 import { useQuery } from '@tanstack/react-query';
+
+import { useMCPClient } from '#contexts/MCPClient/index.ts';
+
 import { agentKeys } from '../keys';
 import type { Agent, ListAgentsParams } from '../types';
 

--- a/apps/beeai-ui/src/modules/agents/api/queries/useListProviderAgents.ts
+++ b/apps/beeai-ui/src/modules/agents/api/queries/useListProviderAgents.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { useMCPClient } from '#contexts/MCPClient/index.ts';
 import { useQuery } from '@tanstack/react-query';
+
+import { useMCPClient } from '#contexts/MCPClient/index.ts';
+
 import { agentKeys } from '../keys';
 import type { ListAgentsParams } from '../types';
 

--- a/apps/beeai-ui/src/modules/agents/api/types.ts
+++ b/apps/beeai-ui/src/modules/agents/api/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ListAgentsRequest, Agent as SdkAgent } from '@i-am-bee/acp-sdk/types';
+import type { Agent as SdkAgent, ListAgentsRequest } from '@i-am-bee/acp-sdk/types';
 import type { Metadata } from '@i-am-bee/beeai-sdk/schemas/metadata';
 
 export type Agent = SdkAgent & Metadata;

--- a/apps/beeai-ui/src/modules/agents/components/AgentCard.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentCard.tsx
@@ -16,14 +16,16 @@
 
 'use client';
 
+import { SkeletonText } from '@carbon/react';
+import type { ReactNode } from 'react';
+
 import { MarkdownContent } from '#components/MarkdownContent/MarkdownContent.tsx';
 import { TagsList } from '#components/TagsList/TagsList.tsx';
-import { SkeletonText } from '@carbon/react';
+
 import type { Agent } from '../api/types';
 import classes from './AgentCard.module.scss';
 import { AgentMetadata } from './AgentMetadata';
 import { AgentTags } from './AgentTags';
-import type { ReactNode } from 'react';
 import { BeeBadge } from './BeeBadge';
 
 interface Props {

--- a/apps/beeai-ui/src/modules/agents/components/AgentDetail.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentDetail.tsx
@@ -16,17 +16,19 @@
 
 'use client';
 
-import { CopySnippet } from '#components/CopySnippet/CopySnippet.tsx';
-import { MarkdownContent } from '#components/MarkdownContent/MarkdownContent.tsx';
-import { TagsList } from '#components/TagsList/TagsList.tsx';
-import commands from '#utils/commands.ts';
-import { fadeProps } from '#utils/fadeProps.ts';
 import { spacing } from '@carbon/layout';
 import { moderate01 } from '@carbon/motion';
 import { ButtonSkeleton, SkeletonText } from '@carbon/react';
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
 import type { ReactNode } from 'react';
+
+import { CopySnippet } from '#components/CopySnippet/CopySnippet.tsx';
+import { MarkdownContent } from '#components/MarkdownContent/MarkdownContent.tsx';
+import { TagsList } from '#components/TagsList/TagsList.tsx';
+import commands from '#utils/commands.ts';
+import { fadeProps } from '#utils/fadeProps.ts';
+
 import type { Agent } from '../api/types';
 import { AgentLaunchButton } from '../detail/AgentLaunchButton';
 import classes from './AgentDetail.module.scss';

--- a/apps/beeai-ui/src/modules/agents/components/AgentDetailSection.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentDetailSection.tsx
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import type { ReactNode } from 'react';
 import { SkeletonText, type SkeletonTextProps } from '@carbon/react';
 import clsx from 'clsx';
+import type { ReactNode } from 'react';
+
 import classes from './AgentDetailSection.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/modules/agents/components/AgentExampleRequests.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentExampleRequests.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@carbon/react';
+import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@carbon/react';
+
 import { MarkdownContent } from '#components/MarkdownContent/MarkdownContent.tsx';
 import { createCodeBlock } from '#utils/markdown.ts';
 

--- a/apps/beeai-ui/src/modules/agents/components/AgentMetadata.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentMetadata.tsx
@@ -17,6 +17,7 @@
 import { LogoGithub, Time } from '@carbon/icons-react';
 import { SkeletonText } from '@carbon/react';
 import clsx from 'clsx';
+
 import type { Agent } from '../api/types';
 import classes from './AgentMetadata.module.scss';
 

--- a/apps/beeai-ui/src/modules/agents/components/AgentModal.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentModal.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import { ArrowUpRight } from '@carbon/icons-react';
+import { Button, ModalBody, ModalHeader } from '@carbon/react';
+
 import { CopySnippet } from '#components/CopySnippet/CopySnippet.tsx';
 import { Modal } from '#components/Modal/Modal.tsx';
 import type { ModalProps } from '#contexts/Modal/modal-context.ts';
-import { ArrowUpRight } from '@carbon/icons-react';
-import { Button, ModalBody, ModalHeader } from '@carbon/react';
+
 import type { Agent } from '../api/types';
 import { AgentMetadata } from './AgentMetadata';
 import classes from './AgentModal.module.scss';

--- a/apps/beeai-ui/src/modules/agents/components/AgentTags.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentTags.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import type { ReactElement } from 'react';
 import { Tag } from '@carbon/react';
+import type { TagBaseProps } from '@carbon/react/lib/components/Tag/Tag';
+import type { ReactElement } from 'react';
+
 import { TagsList } from '#components/TagsList/TagsList.tsx';
 import { isNotNull } from '#utils/helpers.ts';
+
 import type { Agent } from '../api/types';
-import type { TagBaseProps } from '@carbon/react/lib/components/Tag/Tag';
 
 interface Props {
   agent: Agent;

--- a/apps/beeai-ui/src/modules/agents/components/AgentsFilters.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentsFilters.tsx
@@ -16,9 +16,6 @@
 
 'use client';
 
-import { FiltersPopover, type Group } from '#components/FiltersPopover/FiltersPopover.tsx';
-import { TagsList } from '#components/TagsList/TagsList.tsx';
-import { type AgentsCountedOccurrence, countOccurrences } from '#utils/agents/countOccurrences.ts';
 import { Search } from '@carbon/icons-react';
 import { OperationalTag, TextInput, TextInputSkeleton } from '@carbon/react';
 import clsx from 'clsx';
@@ -26,6 +23,11 @@ import isEmpty from 'lodash/isEmpty';
 import xor from 'lodash/xor';
 import { useId, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
+
+import { FiltersPopover, type Group } from '#components/FiltersPopover/FiltersPopover.tsx';
+import { TagsList } from '#components/TagsList/TagsList.tsx';
+import { type AgentsCountedOccurrence, countOccurrences } from '#utils/agents/countOccurrences.ts';
+
 import type { Agent } from '../api/types';
 import type { AgentsFiltersParams } from '../providers/AgentsFiltersProvider';
 import classes from './AgentsFilters.module.scss';

--- a/apps/beeai-ui/src/modules/agents/components/AgentsList.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/AgentsList.tsx
@@ -19,12 +19,14 @@
 import { SkeletonText } from '@carbon/react';
 import pluralize from 'pluralize';
 import type { ReactNode } from 'react';
+
+import { SkeletonItems } from '#components/SkeletonItems/SkeletonItems.tsx';
+
+import type { Agent } from '../api/types';
 import { useFilteredAgents } from '../hooks/useFilteredAgents';
 import type { AgentsFiltersParams } from '../providers/AgentsFiltersProvider';
-import classes from './AgentsList.module.scss';
-import type { Agent } from '../api/types';
-import { SkeletonItems } from '#components/SkeletonItems/SkeletonItems.tsx';
 import { AgentCard } from './AgentCard';
+import classes from './AgentsList.module.scss';
 
 interface Props {
   agents: Agent[] | undefined;

--- a/apps/beeai-ui/src/modules/agents/components/BeeBadge.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/BeeBadge.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import type { ComponentProps } from 'react';
 import { Tag } from '@carbon/react';
-import { BEE_AI_FRAMEWORK_TAG } from '#utils/constants.ts';
+import type { ComponentProps } from 'react';
+
 import { Tooltip } from '#components/Tooltip/Tooltip.tsx';
 import Bee from '#svgs/bee.svg';
+import { BEE_AI_FRAMEWORK_TAG } from '#utils/constants.ts';
+
 import type { Agent } from '../api/types';
 import classes from './BeeBadge.module.scss';
 

--- a/apps/beeai-ui/src/modules/agents/components/ImportAgents.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/ImportAgents.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import { useModal } from '#contexts/Modal/index.tsx';
 import { Add } from '@carbon/icons-react';
 import { Button } from '@carbon/react';
+
+import { useModal } from '#contexts/Modal/index.tsx';
+
 import { ImportAgentsModal } from './ImportAgentsModal';
 
 export function ImportAgents() {

--- a/apps/beeai-ui/src/modules/agents/components/ImportAgentsModal.tsx
+++ b/apps/beeai-ui/src/modules/agents/components/ImportAgentsModal.tsx
@@ -14,14 +14,6 @@
  * limitations under the License.
  */
 
-import { ErrorMessage } from '#components/ErrorMessage/ErrorMessage.tsx';
-import { Modal } from '#components/Modal/Modal.tsx';
-import type { ModalProps } from '#contexts/Modal/modal-context.ts';
-import { useCreateProvider } from '#modules/providers/api/mutations/useCreateProvider.ts';
-import type { CreateProviderBody } from '#modules/providers/api/types.ts';
-import { ProviderSourcePrefixes } from '#modules/providers/constants.ts';
-import { useMonitorProvider } from '#modules/providers/hooks/useMonitorProviderStatus.ts';
-import { ProviderSource } from '#modules/providers/types.ts';
 import {
   Button,
   FormLabel,
@@ -38,6 +30,16 @@ import {
 import pluralize from 'pluralize';
 import { useCallback, useEffect, useId, useState } from 'react';
 import { useController, useForm } from 'react-hook-form';
+
+import { ErrorMessage } from '#components/ErrorMessage/ErrorMessage.tsx';
+import { Modal } from '#components/Modal/Modal.tsx';
+import type { ModalProps } from '#contexts/Modal/modal-context.ts';
+import { useCreateProvider } from '#modules/providers/api/mutations/useCreateProvider.ts';
+import type { CreateProviderBody } from '#modules/providers/api/types.ts';
+import { ProviderSourcePrefixes } from '#modules/providers/constants.ts';
+import { useMonitorProvider } from '#modules/providers/hooks/useMonitorProviderStatus.ts';
+import { ProviderSource } from '#modules/providers/types.ts';
+
 import classes from './ImportAgentsModal.module.scss';
 
 export function ImportAgentsModal({ onRequestClose, ...modalProps }: ModalProps) {

--- a/apps/beeai-ui/src/modules/agents/detail/AgentDetailView.tsx
+++ b/apps/beeai-ui/src/modules/agents/detail/AgentDetailView.tsx
@@ -15,6 +15,7 @@
  */
 
 import { ErrorMessage } from '#components/ErrorMessage/ErrorMessage.tsx';
+
 import { useAgent } from '../api/queries/useAgent';
 import { AgentDetail } from '../components/AgentDetail';
 import { AgentLaunchButton } from './AgentLaunchButton';

--- a/apps/beeai-ui/src/modules/agents/detail/AgentLaunchButton.tsx
+++ b/apps/beeai-ui/src/modules/agents/detail/AgentLaunchButton.tsx
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
+import { ArrowRight } from '@carbon/icons-react';
+import { Button, ButtonSkeleton } from '@carbon/react';
+import clsx from 'clsx';
+import isEmpty from 'lodash/isEmpty';
+
 import { TransitionLink } from '#components/TransitionLink/TransitionLink.tsx';
 import { useModal } from '#contexts/Modal/index.tsx';
 import { AddRequiredEnvsModal } from '#modules/envs/components/AddRequiredEnvsModal.tsx';
 import { SupportedUis } from '#modules/run/constants.ts';
 import type { UiType } from '#modules/run/types.ts';
 import { routes } from '#utils/router.ts';
-import { ArrowRight } from '@carbon/icons-react';
-import { Button, ButtonSkeleton } from '@carbon/react';
-import clsx from 'clsx';
-import isEmpty from 'lodash/isEmpty';
+
 import type { Agent } from '../api/types';
 import { useMissingEnvs } from '../hooks/useMissingEnvs';
 import classes from './AgentLaunchButton.module.scss';

--- a/apps/beeai-ui/src/modules/agents/hooks/useFilteredAgents.ts
+++ b/apps/beeai-ui/src/modules/agents/hooks/useFilteredAgents.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import { compareStrings } from '#utils/helpers.ts';
 import intersection from 'lodash/intersection';
 import { useMemo } from 'react';
+
+import { compareStrings } from '#utils/helpers.ts';
+
 import type { Agent } from '../api/types';
 import type { AgentsFiltersParams } from '../providers/AgentsFiltersProvider';
 

--- a/apps/beeai-ui/src/modules/agents/hooks/useMissingEnvs.ts
+++ b/apps/beeai-ui/src/modules/agents/hooks/useMissingEnvs.ts
@@ -15,6 +15,7 @@
  */
 
 import { useProvider } from '#modules/providers/api/queries/useProvider.ts';
+
 import type { Agent } from '../api/types';
 
 interface Props {

--- a/apps/beeai-ui/src/modules/agents/list/AgentsView.tsx
+++ b/apps/beeai-ui/src/modules/agents/list/AgentsView.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+import { useFormContext } from 'react-hook-form';
+
 import { ErrorMessage } from '#components/ErrorMessage/ErrorMessage.tsx';
 import { TransitionLink } from '#components/TransitionLink/TransitionLink.tsx';
 import { routes } from '#utils/router.ts';
-import { useFormContext } from 'react-hook-form';
+
 import { useListAgents } from '../api/queries/useListAgents';
 import type { Agent } from '../api/types';
 import { AgentCard } from '../components/AgentCard';

--- a/apps/beeai-ui/src/modules/agents/utils.ts
+++ b/apps/beeai-ui/src/modules/agents/utils.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { isNotNull } from '#utils/helpers.ts';
 import uniq from 'lodash/uniq';
+
+import { isNotNull } from '#utils/helpers.ts';
+
 import type { Agent } from './api/types';
 
 export const getAgentsLanguages = (agents: Agent[] | undefined) =>

--- a/apps/beeai-ui/src/modules/compose/ComposeLanding.tsx
+++ b/apps/beeai-ui/src/modules/compose/ComposeLanding.tsx
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-import { TransitionLink } from '#components/TransitionLink/TransitionLink.tsx';
-import { VersionTag } from '#components/VersionTag/VersionTag.tsx';
-import { Container } from '#components/layouts/Container.tsx';
-import { MainContent } from '#components/layouts/MainContent.tsx';
-import { routes } from '#utils/router.ts';
 import { ArrowRight } from '@carbon/icons-react';
 import { Button } from '@carbon/react';
 import { useState } from 'react';
-import classes from './ComposeLanding.module.scss';
+
+import { Container } from '#components/layouts/Container.tsx';
+import { MainContent } from '#components/layouts/MainContent.tsx';
+import { TransitionLink } from '#components/TransitionLink/TransitionLink.tsx';
+import { VersionTag } from '#components/VersionTag/VersionTag.tsx';
+import { routes } from '#utils/router.ts';
+
 import SequentialIllustration from './assets/sequential.svg';
 import SupervisorIllustration from './assets/supervisor.svg';
+import classes from './ComposeLanding.module.scss';
 
 export function ComposeLanding() {
   const [selected, setSelected] = useState<Workflow>(WORKFLOWS.at(0)!);

--- a/apps/beeai-ui/src/modules/compose/ComposeSequential.tsx
+++ b/apps/beeai-ui/src/modules/compose/ComposeSequential.tsx
@@ -15,6 +15,7 @@
  */
 
 import { FormProvider, useForm } from 'react-hook-form';
+
 import { ComposeView } from './components/ComposeView';
 import type { SequentialFormValues } from './contexts/compose-context';
 import { ComposeProvider } from './contexts/ComposeProvider';

--- a/apps/beeai-ui/src/modules/compose/components/AddAgentButton.tsx
+++ b/apps/beeai-ui/src/modules/compose/components/AddAgentButton.tsx
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
-import { SkeletonItems } from '#components/SkeletonItems/SkeletonItems.tsx';
-import { useListAgents } from '#modules/agents/api/queries/useListAgents.ts';
-import type { Agent } from '#modules/agents/api/types.ts';
-import { compareStrings } from '#utils/helpers.ts';
 import { Add } from '@carbon/icons-react';
 import { Button } from '@carbon/react';
 import type { RefObject } from 'react';
 import { useId, useMemo, useRef, useState } from 'react';
 import { useOnClickOutside } from 'usehooks-ts';
+
+import { SkeletonItems } from '#components/SkeletonItems/SkeletonItems.tsx';
+import { useListAgents } from '#modules/agents/api/queries/useListAgents.ts';
+import type { Agent } from '#modules/agents/api/types.ts';
+import { compareStrings } from '#utils/helpers.ts';
+
 import { isValidForSequentialWorkflow } from '../sequential/utils';
 import classes from './AddAgentButton.module.scss';
 import { AgentListOption } from './AgentListOption';

--- a/apps/beeai-ui/src/modules/compose/components/AgentListOption.tsx
+++ b/apps/beeai-ui/src/modules/compose/components/AgentListOption.tsx
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-import { TagsList } from '#components/TagsList/TagsList.tsx';
-import type { Agent } from '#modules/agents/api/types.ts';
-import { AgentTags } from '#modules/agents/components/AgentTags.tsx';
 import { SkeletonText } from '@carbon/react';
 import clsx from 'clsx';
 import type { MouseEvent } from 'react';
-import classes from './AgentListOption.module.scss';
+
+import { TagsList } from '#components/TagsList/TagsList.tsx';
+import type { Agent } from '#modules/agents/api/types.ts';
+import { AgentTags } from '#modules/agents/components/AgentTags.tsx';
 import { BeeBadge } from '#modules/agents/components/BeeBadge.tsx';
+
+import classes from './AgentListOption.module.scss';
 
 interface Props {
   agent: Agent;

--- a/apps/beeai-ui/src/modules/compose/components/ComposeResult.tsx
+++ b/apps/beeai-ui/src/modules/compose/components/ComposeResult.tsx
@@ -16,6 +16,7 @@
 
 import { useAutoScroll } from '#hooks/useAutoScroll.ts';
 import { AgentOutputBox } from '#modules/run/components/AgentOutputBox.tsx';
+
 import { useCompose } from '../contexts';
 
 export function ComposeResult() {

--- a/apps/beeai-ui/src/modules/compose/components/ComposeStepListItem.tsx
+++ b/apps/beeai-ui/src/modules/compose/components/ComposeStepListItem.tsx
@@ -16,13 +16,15 @@
 
 import { OverflowMenu, OverflowMenuItem } from '@carbon/react';
 import clsx from 'clsx';
+import type { KeyboardEvent } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { Spinner } from '#components/Spinner/Spinner.tsx';
+import { TextAreaAutoHeight } from '#components/TextAreaAutoHeight/TextAreaAutoHeight.tsx';
+
+import { useCompose } from '../contexts';
 import type { SequentialFormValues } from '../contexts/compose-context';
 import classes from './ComposeStepListItem.module.scss';
-import { useFormContext } from 'react-hook-form';
-import { TextAreaAutoHeight } from '#components/TextAreaAutoHeight/TextAreaAutoHeight.tsx';
-import { useCompose } from '../contexts';
-import type { KeyboardEvent } from 'react';
-import { Spinner } from '#components/Spinner/Spinner.tsx';
 import { StepResult } from './StepResult';
 
 interface Props {

--- a/apps/beeai-ui/src/modules/compose/components/ComposeView.tsx
+++ b/apps/beeai-ui/src/modules/compose/components/ComposeView.tsx
@@ -15,6 +15,7 @@
  */
 
 import { SplitPanesView } from '#components/SplitPanesView/SplitPanesView.tsx';
+
 import { useCompose } from '../contexts';
 import { SequentialSetup } from '../sequential/SequentialSetup';
 import { ComposeResult } from './ComposeResult';

--- a/apps/beeai-ui/src/modules/compose/components/StepResult.tsx
+++ b/apps/beeai-ui/src/modules/compose/components/StepResult.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import { Accordion, AccordionItem } from '@carbon/react';
+import clsx from 'clsx';
+
 import { MarkdownContent } from '#components/MarkdownContent/MarkdownContent.tsx';
 import { useAutoScroll } from '#hooks/useAutoScroll.ts';
 import { AgentRunLogItem } from '#modules/run/components/AgentRunLogItem.tsx';
-import { Accordion, AccordionItem } from '@carbon/react';
-import clsx from 'clsx';
+
 import type { ComposeStep } from '../contexts/compose-context';
 import classes from './StepResult.module.scss';
 

--- a/apps/beeai-ui/src/modules/compose/contexts/ComposeProvider.tsx
+++ b/apps/beeai-ui/src/modules/compose/contexts/ComposeProvider.tsx
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
+import type { PropsWithChildren } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import { useSearchParams } from 'react-router';
+
 import { useHandleError } from '#hooks/useHandleError.ts';
 import { usePrevious } from '#hooks/usePrevious.ts';
 import { useListAgents } from '#modules/agents/api/queries/useListAgents.ts';
 import { useRunAgent } from '#modules/run/api/mutations/useRunAgent.tsx';
 import type { TextResult } from '#modules/run/api/types.ts';
 import { isNotNull } from '#utils/helpers.ts';
-import type { PropsWithChildren } from 'react';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { useFieldArray, useFormContext } from 'react-hook-form';
-import { useSearchParams } from 'react-router';
+
 import { SEQUENTIAL_COMPOSE_AGENT_NAME } from '../sequential/constants';
 import type { SequentialWorkflowInput } from '../sequential/types';
 import { getSequentialComposeAgent } from '../sequential/utils';

--- a/apps/beeai-ui/src/modules/compose/contexts/compose-context.tsx
+++ b/apps/beeai-ui/src/modules/compose/contexts/compose-context.tsx
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import type { Agent } from '#modules/agents/api/types.ts';
-import type { RunStats } from '#modules/run/types.ts';
 import { createContext } from 'react';
 import type { UseFieldArrayReturn } from 'react-hook-form';
+
+import type { Agent } from '#modules/agents/api/types.ts';
+import type { RunStats } from '#modules/run/types.ts';
 
 export const ComposeContext = createContext<ComposeContextValue | null>(null);
 

--- a/apps/beeai-ui/src/modules/compose/contexts/index.ts
+++ b/apps/beeai-ui/src/modules/compose/contexts/index.ts
@@ -15,6 +15,7 @@
  */
 
 import { useContext } from 'react';
+
 import { ComposeContext } from './compose-context';
 
 export function useCompose() {

--- a/apps/beeai-ui/src/modules/compose/sequential/SequentialSetup.tsx
+++ b/apps/beeai-ui/src/modules/compose/sequential/SequentialSetup.tsx
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
+import { ArrowLeft, PlayFilledAlt, StopOutlineFilled } from '@carbon/icons-react';
+import { Button, IconButton } from '@carbon/react';
+import clsx from 'clsx';
+import { useFormState } from 'react-hook-form';
+
 import { TransitionLink } from '#components/TransitionLink/TransitionLink.tsx';
 import { VersionTag } from '#components/VersionTag/VersionTag.tsx';
 import type { Agent } from '#modules/agents/api/types.ts';
 import NewSession from '#modules/run/components/NewSession.svg';
 import { routes } from '#utils/router.ts';
-import { ArrowLeft, PlayFilledAlt, StopOutlineFilled } from '@carbon/icons-react';
-import { Button, IconButton } from '@carbon/react';
-import clsx from 'clsx';
-import { useFormState } from 'react-hook-form';
+
 import { AddAgentButton } from '../components/AddAgentButton';
 import { ComposeStepListItem } from '../components/ComposeStepListItem';
 import { useCompose } from '../contexts';

--- a/apps/beeai-ui/src/modules/compose/sequential/utils.ts
+++ b/apps/beeai-ui/src/modules/compose/sequential/utils.ts
@@ -18,6 +18,7 @@ import type { JSONSchema } from '#helpers/validateJsonSchema.ts';
 import { validateJsonSchema } from '#helpers/validateJsonSchema.ts';
 import type { Agent } from '#modules/agents/api/types.ts';
 import { UiType } from '#modules/run/types.ts';
+
 import { SEQUENTIAL_COMPOSE_AGENT_NAME, textInputJsonSchema, textOutputJsonSchema } from './constants';
 
 export function isValidForSequentialWorkflow(agent: Agent) {

--- a/apps/beeai-ui/src/modules/envs/api/index.ts
+++ b/apps/beeai-ui/src/modules/envs/api/index.ts
@@ -15,6 +15,7 @@
  */
 
 import { api } from '#api/index.ts';
+
 import type { CreateEnvBody } from './types';
 
 export async function createEnv({ body }: { body: CreateEnvBody['env'] }) {

--- a/apps/beeai-ui/src/modules/envs/api/mutations/useCreateEnv.ts
+++ b/apps/beeai-ui/src/modules/envs/api/mutations/useCreateEnv.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { providerKeys } from '#modules/providers/api/keys.ts';
 import { useMutation } from '@tanstack/react-query';
+
+import { providerKeys } from '#modules/providers/api/keys.ts';
+
 import { createEnv } from '..';
 import { envKeys } from '../keys';
 

--- a/apps/beeai-ui/src/modules/envs/api/mutations/useDeleteEnv.ts
+++ b/apps/beeai-ui/src/modules/envs/api/mutations/useDeleteEnv.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { providerKeys } from '#modules/providers/api/keys.ts';
 import { useMutation } from '@tanstack/react-query';
+
+import { providerKeys } from '#modules/providers/api/keys.ts';
+
 import { deleteEnv } from '..';
 import { envKeys } from '../keys';
 

--- a/apps/beeai-ui/src/modules/envs/api/queries/useListEnvs.ts
+++ b/apps/beeai-ui/src/modules/envs/api/queries/useListEnvs.ts
@@ -15,6 +15,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+
 import { getEnvs } from '..';
 import { envKeys } from '../keys';
 

--- a/apps/beeai-ui/src/modules/envs/components/AddEnvModal.tsx
+++ b/apps/beeai-ui/src/modules/envs/components/AddEnvModal.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-import { Modal } from '#components/Modal/Modal.tsx';
-import type { ModalProps } from '#contexts/Modal/modal-context.ts';
 import { Button, InlineLoading, ModalBody, ModalFooter, ModalHeader, TextInput } from '@carbon/react';
 import { useCallback, useId } from 'react';
 import { useForm } from 'react-hook-form';
+
+import { Modal } from '#components/Modal/Modal.tsx';
+import type { ModalProps } from '#contexts/Modal/modal-context.ts';
+
 import { useCreateEnv } from '../api/mutations/useCreateEnv';
 import classes from './AddEnvModal.module.scss';
 

--- a/apps/beeai-ui/src/modules/envs/components/AddRequiredEnvsModal.tsx
+++ b/apps/beeai-ui/src/modules/envs/components/AddRequiredEnvsModal.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import { Modal } from '#components/Modal/Modal.tsx';
-import type { ModalProps } from '#contexts/Modal/modal-context.ts';
-import type { MissingEnvs } from '#modules/providers/api/types.ts';
 import { Button, InlineLoading, ModalBody, ModalFooter, ModalHeader, TextInput } from '@carbon/react';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
+
+import { Modal } from '#components/Modal/Modal.tsx';
+import type { ModalProps } from '#contexts/Modal/modal-context.ts';
+import type { MissingEnvs } from '#modules/providers/api/types.ts';
+
 import { useCreateEnv } from '../api/mutations/useCreateEnv';
 import classes from './AddRequiredEnvsModal.module.scss';
 

--- a/apps/beeai-ui/src/modules/envs/components/EnvsView.tsx
+++ b/apps/beeai-ui/src/modules/envs/components/EnvsView.tsx
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-import { TableView } from '#components/TableView/TableView.tsx';
-import { TableViewActions } from '#components/TableView/TableViewActions.tsx';
-import { TableViewToolbar } from '#components/TableView/TableViewToolbar.tsx';
-import { useModal } from '#contexts/Modal/index.tsx';
-import { useTableSearch } from '#hooks/useTableSearch.ts';
 import { TrashCan } from '@carbon/icons-react';
 import {
   Button,
@@ -33,6 +28,13 @@ import {
   TableRow,
 } from '@carbon/react';
 import { useMemo } from 'react';
+
+import { TableView } from '#components/TableView/TableView.tsx';
+import { TableViewActions } from '#components/TableView/TableViewActions.tsx';
+import { TableViewToolbar } from '#components/TableView/TableViewToolbar.tsx';
+import { useModal } from '#contexts/Modal/index.tsx';
+import { useTableSearch } from '#hooks/useTableSearch.ts';
+
 import { useDeleteEnv } from '../api/mutations/useDeleteEnv';
 import { useListEnvs } from '../api/queries/useListEnvs';
 import { AddEnvModal } from './AddEnvModal';

--- a/apps/beeai-ui/src/modules/home/components/GettingStarted.tsx
+++ b/apps/beeai-ui/src/modules/home/components/GettingStarted.tsx
@@ -16,13 +16,15 @@
 
 'use client';
 
+import { BREW_INSTALL_BEEAI } from '@i-am-bee/beeai-ui';
+
 import { CopySnippet } from '#components/CopySnippet/CopySnippet.tsx';
 import { Container } from '#components/layouts/Container.tsx';
-import { BREW_INSTALL_BEEAI } from '@i-am-bee/beeai-ui';
+
 import classes from './GettingStarted.module.scss';
 import { GitHubButton } from './GitHubButton';
 import { LogoBeeAI } from './LogoBeeAI';
-import { type VideoBeeAIProps, VideoBeeAI } from './VideoBeeAI';
+import { VideoBeeAI, type VideoBeeAIProps } from './VideoBeeAI';
 
 interface GettingStartedProps {
   video: VideoBeeAIProps;

--- a/apps/beeai-ui/src/modules/home/components/GitHubButton.tsx
+++ b/apps/beeai-ui/src/modules/home/components/GitHubButton.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import { GITHUB_REPO_LINK } from '#utils/constants.ts';
-import { Button } from '@carbon/react';
 import { LogoGithub } from '@carbon/icons-react';
+import { Button } from '@carbon/react';
+
+import { GITHUB_REPO_LINK } from '#utils/constants.ts';
+
 import classes from './GitHubButton.module.scss';
 
 export function GitHubButton() {

--- a/apps/beeai-ui/src/modules/home/components/LogoBeeAI.tsx
+++ b/apps/beeai-ui/src/modules/home/components/LogoBeeAI.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import Logo from '#svgs/LogoBeeAI.svg';
 import clsx from 'clsx';
 import { lazy, useState } from 'react';
+
+import Logo from '#svgs/LogoBeeAI.svg';
+
 import animationData from './LogoBeeAI.json';
 import classes from './LogoBeeAI.module.scss';
 

--- a/apps/beeai-ui/src/modules/home/components/PlayButton.tsx
+++ b/apps/beeai-ui/src/modules/home/components/PlayButton.tsx
@@ -16,6 +16,7 @@
 
 import { PlayFilled } from '@carbon/icons-react';
 import clsx from 'clsx';
+
 import classes from './PlayButton.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/modules/home/components/VideoBeeAI.tsx
+++ b/apps/beeai-ui/src/modules/home/components/VideoBeeAI.tsx
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
+import { useEffect, useRef, useState } from 'react';
+import { mergeRefs } from 'react-merge-refs';
+import { useIntersectionObserver } from 'usehooks-ts';
+
 import { PlayButton } from './PlayButton';
 import classes from './VideoBeeAI.module.scss';
-import { useIntersectionObserver } from 'usehooks-ts';
-import { mergeRefs } from 'react-merge-refs';
 
 export interface VideoBeeAIProps {
   src: string;

--- a/apps/beeai-ui/src/modules/phoenix/api/queries/usePhoenix.ts
+++ b/apps/beeai-ui/src/modules/phoenix/api/queries/usePhoenix.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { PHOENIX_SERVER_TARGET } from '#utils/vite-constants.ts';
 import { useQuery } from '@tanstack/react-query';
+
+import { PHOENIX_SERVER_TARGET } from '#utils/vite-constants.ts';
+
 import { phoenixKeys } from '../keys';
 
 export function usePhoenix() {

--- a/apps/beeai-ui/src/modules/providers/api/index.ts
+++ b/apps/beeai-ui/src/modules/providers/api/index.ts
@@ -15,6 +15,7 @@
  */
 
 import { api } from '#api/index.ts';
+
 import type { CreateProviderBody } from './types';
 
 export async function createProvider({ body }: { body: CreateProviderBody }) {

--- a/apps/beeai-ui/src/modules/providers/api/mutations/useCreateProvider.ts
+++ b/apps/beeai-ui/src/modules/providers/api/mutations/useCreateProvider.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { agentKeys } from '#modules/agents/api/keys.ts';
 import { useMutation } from '@tanstack/react-query';
+
+import { agentKeys } from '#modules/agents/api/keys.ts';
+
 import { createProvider } from '..';
 import { providerKeys } from '../keys';
 import type { CreateProviderResponse } from '../types';

--- a/apps/beeai-ui/src/modules/providers/api/mutations/useDeleteProvider.ts
+++ b/apps/beeai-ui/src/modules/providers/api/mutations/useDeleteProvider.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import { agentKeys } from '#modules/agents/api/keys.ts';
 import type { Agent } from '#modules/agents/api/types.ts';
 import { providerKeys } from '#modules/providers/api/keys.ts';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import { deleteProvider } from '..';
 
 export function useDeleteProvider() {

--- a/apps/beeai-ui/src/modules/providers/api/queries/useListProviders.ts
+++ b/apps/beeai-ui/src/modules/providers/api/queries/useListProviders.ts
@@ -15,6 +15,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+
 import { getProviders } from '..';
 import { providerKeys } from '../keys';
 

--- a/apps/beeai-ui/src/modules/providers/api/queries/useProvider.ts
+++ b/apps/beeai-ui/src/modules/providers/api/queries/useProvider.ts
@@ -15,6 +15,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+
 import { getProviders } from '..';
 import { providerKeys } from '../keys';
 import type { Provider, ProvidersList } from '../types';

--- a/apps/beeai-ui/src/modules/providers/components/ProvidersView.tsx
+++ b/apps/beeai-ui/src/modules/providers/components/ProvidersView.tsx
@@ -14,14 +14,6 @@
  * limitations under the License.
  */
 
-import { TableView } from '#components/TableView/TableView.tsx';
-import { TableViewActions } from '#components/TableView/TableViewActions.tsx';
-import { TableViewToolbar } from '#components/TableView/TableViewToolbar.tsx';
-import { useModal } from '#contexts/Modal/index.tsx';
-import { useTableSearch } from '#hooks/useTableSearch.ts';
-import { useListAgents } from '#modules/agents/api/queries/useListAgents.ts';
-import { ImportAgentsModal } from '#modules/agents/components/ImportAgentsModal.tsx';
-import { getAgentsLanguages } from '#modules/agents/utils.ts';
 import { TrashCan } from '@carbon/icons-react';
 import {
   Button,
@@ -36,6 +28,16 @@ import {
   TableRow,
 } from '@carbon/react';
 import { useMemo } from 'react';
+
+import { TableView } from '#components/TableView/TableView.tsx';
+import { TableViewActions } from '#components/TableView/TableViewActions.tsx';
+import { TableViewToolbar } from '#components/TableView/TableViewToolbar.tsx';
+import { useModal } from '#contexts/Modal/index.tsx';
+import { useTableSearch } from '#hooks/useTableSearch.ts';
+import { useListAgents } from '#modules/agents/api/queries/useListAgents.ts';
+import { ImportAgentsModal } from '#modules/agents/components/ImportAgentsModal.tsx';
+import { getAgentsLanguages } from '#modules/agents/utils.ts';
+
 import { useDeleteProvider } from '../api/mutations/useDeleteProvider';
 import { useListProviders } from '../api/queries/useListProviders';
 import { getProviderSource, groupAgentsByProvider, stripProviderSourcePrefix } from '../utils';

--- a/apps/beeai-ui/src/modules/providers/hooks/useMonitorProviderStatus.ts
+++ b/apps/beeai-ui/src/modules/providers/hooks/useMonitorProviderStatus.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
+import { useQueryClient } from '@tanstack/react-query';
+import pluralize from 'pluralize';
+import { useCallback, useEffect, useState } from 'react';
+
 import { useToast } from '#contexts/Toast/index.ts';
 import { TaskType, useTasks } from '#hooks/useTasks.ts';
 import { agentKeys } from '#modules/agents/api/keys.ts';
 import { useListProviderAgents } from '#modules/agents/api/queries/useListProviderAgents.ts';
-import { useQueryClient } from '@tanstack/react-query';
-import pluralize from 'pluralize';
-import { useCallback, useEffect, useState } from 'react';
+
 import { useProvider } from '../api/queries/useProvider';
 
 interface Props {

--- a/apps/beeai-ui/src/modules/providers/utils.ts
+++ b/apps/beeai-ui/src/modules/providers/utils.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import type { Agent } from '#modules/agents/api/types.ts';
 import groupBy from 'lodash/groupBy';
+
+import type { Agent } from '#modules/agents/api/types.ts';
+
 import { ProviderSourcePrefixes } from './constants';
 
 export const getProviderSource = (id: string) => {

--- a/apps/beeai-ui/src/modules/run/api/mutations/useRunAgent.tsx
+++ b/apps/beeai-ui/src/modules/run/api/mutations/useRunAgent.tsx
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import { useCreateMCPClient } from '#api/mcp-client/useCreateMCPClient.ts';
-import type { QueryMetadata } from '#contexts/QueryProvider/types.ts';
-import type { Agent } from '#modules/agents/api/types.ts';
 import { AgentRunProgressNotificationSchema } from '@i-am-bee/acp-sdk/types';
 import { useMutation } from '@tanstack/react-query';
 import type z from 'zod';
 import type { ZodLiteral, ZodObject } from 'zod';
+
+import { useCreateMCPClient } from '#api/mcp-client/useCreateMCPClient.ts';
+import type { QueryMetadata } from '#contexts/QueryProvider/types.ts';
+import type { Agent } from '#modules/agents/api/types.ts';
 
 interface Props<
   NotificationsSchema extends ZodObject<{

--- a/apps/beeai-ui/src/modules/run/chat/Chat.tsx
+++ b/apps/beeai-ui/src/modules/run/chat/Chat.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import { Container } from '#components/layouts/Container.tsx';
 import { ArrowDown } from '@carbon/icons-react';
 import { IconButton } from '@carbon/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Container } from '#components/layouts/Container.tsx';
+
 import { AgentHeader } from '../components/AgentHeader';
 import { useChat, useChatMessages } from '../contexts/chat';
 import classes from './Chat.module.scss';

--- a/apps/beeai-ui/src/modules/run/chat/ChatInput.tsx
+++ b/apps/beeai-ui/src/modules/run/chat/ChatInput.tsx
@@ -18,6 +18,7 @@ import { Send, StopOutlineFilled } from '@carbon/icons-react';
 import { Button } from '@carbon/react';
 import { memo, useCallback, useRef } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+
 import type { InputBarFormHandle } from '../components/InputBar';
 import { InputBar } from '../components/InputBar';
 import { useChat } from '../contexts/chat';

--- a/apps/beeai-ui/src/modules/run/chat/ChatSettings.tsx
+++ b/apps/beeai-ui/src/modules/run/chat/ChatSettings.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { fadeProps } from '#utils/fadeProps.ts';
 import { Settings } from '@carbon/icons-react';
 import { IconButton } from '@carbon/react';
 import {
@@ -32,6 +31,9 @@ import {
 import { AnimatePresence, motion } from 'framer-motion';
 import type { RefObject } from 'react';
 import { useState } from 'react';
+
+import { fadeProps } from '#utils/fadeProps.ts';
+
 import classes from './ChatSettings.module.scss';
 import { ChatTools } from './ChatTools';
 

--- a/apps/beeai-ui/src/modules/run/chat/ChatTools.tsx
+++ b/apps/beeai-ui/src/modules/run/chat/ChatTools.tsx
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
+import { useCallback } from 'react';
+import { useFormContext } from 'react-hook-form';
+
 import { ErrorMessage } from '#components/ErrorMessage/ErrorMessage.tsx';
 import { SkeletonItems } from '#components/SkeletonItems/SkeletonItems.tsx';
 import { useListTools } from '#modules/tools/api/queries/useListTools.ts';
-import { useCallback } from 'react';
-import { useFormContext } from 'react-hook-form';
+
 import type { ChatFormValues } from './ChatInput';
 import classes from './ChatTools.module.scss';
-import { ToolToggle } from './ToolToggle';
 import { ChatSupportedTools } from './constants';
+import { ToolToggle } from './ToolToggle';
 
 export function ChatTools() {
   const { setValue, watch } = useFormContext<ChatFormValues>();

--- a/apps/beeai-ui/src/modules/run/chat/Message.tsx
+++ b/apps/beeai-ui/src/modules/run/chat/Message.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import clsx from 'clsx';
+
 import { ErrorMessage } from '#components/ErrorMessage/ErrorMessage.tsx';
 import { Spinner } from '#components/Spinner/Spinner.tsx';
-import clsx from 'clsx';
+
 import { AgentIcon } from '../components/AgentIcon';
 import { useChat } from '../contexts/chat';
 import classes from './Message.module.scss';

--- a/apps/beeai-ui/src/modules/run/chat/ToolToggle.tsx
+++ b/apps/beeai-ui/src/modules/run/chat/ToolToggle.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import type { ToggleProps } from '@carbon/react';
+import { SkeletonIcon, SkeletonText, Toggle, ToggleSkeleton } from '@carbon/react';
+
 import type { Tool } from '#modules/tools/api/types.ts';
 import { ToolIcon } from '#modules/tools/components/ToolIcon.tsx';
 import { ToolName } from '#modules/tools/components/ToolName.tsx';
-import type { ToggleProps } from '@carbon/react';
-import { SkeletonIcon, SkeletonText, Toggle, ToggleSkeleton } from '@carbon/react';
+
 import classes from './ToolToggle.module.scss';
 
 interface Props extends Pick<ToggleProps, 'toggled' | 'onToggle'> {

--- a/apps/beeai-ui/src/modules/run/chat/UserIcon.tsx
+++ b/apps/beeai-ui/src/modules/run/chat/UserIcon.tsx
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import classes from './UserIcon.module.scss';
 import { User } from '@carbon/icons-react';
+
+import classes from './UserIcon.module.scss';
 
 export function UserIcon() {
   return (

--- a/apps/beeai-ui/src/modules/run/components/AgentHeader.tsx
+++ b/apps/beeai-ui/src/modules/run/components/AgentHeader.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import type { Agent } from '#modules/agents/api/types.ts';
 import { IconButton } from '@carbon/react';
 import clsx from 'clsx';
+
+import type { Agent } from '#modules/agents/api/types.ts';
+
 import { AgentIcon } from '../components/AgentIcon';
 import classes from './AgentHeader.module.scss';
 import NewSession from './NewSession.svg';

--- a/apps/beeai-ui/src/modules/run/components/AgentIcon.tsx
+++ b/apps/beeai-ui/src/modules/run/components/AgentIcon.tsx
@@ -15,6 +15,7 @@
  */
 
 import Bee from '#svgs/bee.svg';
+
 import classes from './AgentIcon.module.scss';
 
 export function AgentIcon() {

--- a/apps/beeai-ui/src/modules/run/components/AgentOutputBox.tsx
+++ b/apps/beeai-ui/src/modules/run/components/AgentOutputBox.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import { CopyButton } from '@carbon/react';
+
 import { DownloadButton } from '#components/DownloadButton/DownloadButton.tsx';
 import { MarkdownContent } from '#components/MarkdownContent/MarkdownContent.tsx';
-import { CopyButton } from '@carbon/react';
+
 import classes from './AgentOutputBox.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/modules/run/components/AgentRun.tsx
+++ b/apps/beeai-ui/src/modules/run/components/AgentRun.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import { Loading } from '@carbon/react';
+
 import { ErrorMessage } from '#components/ErrorMessage/ErrorMessage.tsx';
 import { Container } from '#components/layouts/Container.tsx';
 import { MainContent } from '#components/layouts/MainContent.tsx';
 import type { Agent } from '#modules/agents/api/types.ts';
-import { Loading } from '@carbon/react';
+
 import { useAgent } from '../../agents/api/queries/useAgent';
 import { Chat } from '../chat/Chat';
 import { ChatProvider } from '../contexts/chat/ChatProvider';

--- a/apps/beeai-ui/src/modules/run/components/AgentRunLogItem.tsx
+++ b/apps/beeai-ui/src/modules/run/components/AgentRunLogItem.tsx
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import { AnimateHeightChange } from '#components/AnimateHeightChange/AnimateHeightChange.tsx';
 import { ChevronDown } from '@carbon/icons-react';
 import { IconButton } from '@carbon/react';
 import clsx from 'clsx';
 import type { PropsWithChildren } from 'react';
 import { useEffect, useRef, useState } from 'react';
+
+import { AnimateHeightChange } from '#components/AnimateHeightChange/AnimateHeightChange.tsx';
+
 import classes from './AgentRunLogItem.module.scss';
 
 export function AgentRunLogItem({ children }: PropsWithChildren) {

--- a/apps/beeai-ui/src/modules/run/components/AgentRunLogs.tsx
+++ b/apps/beeai-ui/src/modules/run/components/AgentRunLogs.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import { useAutoScroll } from '#hooks/useAutoScroll.ts';
 import { ChevronDown } from '@carbon/icons-react';
 import clsx from 'clsx';
 import { useState } from 'react';
+
+import { useAutoScroll } from '#hooks/useAutoScroll.ts';
+
 import type { TextNotificationLogs } from '../api/types';
 import { AgentRunLogItem } from './AgentRunLogItem';
 import classes from './AgentRunLogs.module.scss';

--- a/apps/beeai-ui/src/modules/run/components/ElapsedTime.tsx
+++ b/apps/beeai-ui/src/modules/run/components/ElapsedTime.tsx
@@ -15,8 +15,8 @@
  */
 
 import clsx from 'clsx';
-
 import { useEffect, useState } from 'react';
+
 import type { RunStats } from '../types';
 import { runDuration } from '../utils';
 import classes from './ElapsedTime.module.scss';

--- a/apps/beeai-ui/src/modules/run/components/InputBar.tsx
+++ b/apps/beeai-ui/src/modules/run/components/InputBar.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import { TextAreaAutoHeight } from '#components/TextAreaAutoHeight/TextAreaAutoHeight.tsx';
-import { dispatchInputEventOnFormTextarea, submitFormOnEnter } from '#utils/formUtils.ts';
 import type { FormEventHandler, PropsWithChildren, ReactNode, Ref, TextareaHTMLAttributes } from 'react';
 import { useImperativeHandle, useRef } from 'react';
+
+import { TextAreaAutoHeight } from '#components/TextAreaAutoHeight/TextAreaAutoHeight.tsx';
+import { dispatchInputEventOnFormTextarea, submitFormOnEnter } from '#utils/formUtils.ts';
+
 import classes from './InputBar.module.scss';
 
 interface Props {

--- a/apps/beeai-ui/src/modules/run/contexts/chat/ChatProvider.tsx
+++ b/apps/beeai-ui/src/modules/run/contexts/chat/ChatProvider.tsx
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
+import type { MessageInput } from '@i-am-bee/beeai-sdk/schemas/message';
+import type { PropsWithChildren } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
+import { v4 as uuid } from 'uuid';
+
 import { useImmerWithGetter } from '#hooks/useImmerWithGetter.ts';
 import type { Agent } from '#modules/agents/api/types.ts';
 import { useRunAgent } from '#modules/run/api/mutations/useRunAgent.tsx';
 import type { MessagesNotificationSchema, MessagesResult } from '#modules/run/api/types.ts';
 import type { AgentMessage, ChatMessage, SendMessageParams } from '#modules/run/chat/types.ts';
-import type { MessageInput } from '@i-am-bee/beeai-sdk/schemas/message';
-import type { PropsWithChildren } from 'react';
-import { useCallback, useMemo, useRef } from 'react';
-import { v4 as uuid } from 'uuid';
+
 import { ChatContext, ChatMessagesContext } from './chat-context';
 
 interface Props {

--- a/apps/beeai-ui/src/modules/run/contexts/chat/chat-context.ts
+++ b/apps/beeai-ui/src/modules/run/contexts/chat/chat-context.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
+import { createContext } from 'react';
+
 import type { Updater } from '#hooks/useImmerWithGetter.ts';
 import type { Agent } from '#modules/agents/api/types.ts';
 import type { ChatMessage, SendMessageParams } from '#modules/run/chat/types.ts';
-import { createContext } from 'react';
 
 export const ChatContext = createContext<ChatContextValue | null>(null);
 

--- a/apps/beeai-ui/src/modules/run/contexts/chat/index.ts
+++ b/apps/beeai-ui/src/modules/run/contexts/chat/index.ts
@@ -15,6 +15,7 @@
  */
 
 import { use } from 'react';
+
 import { ChatContext, ChatMessagesContext } from './chat-context';
 
 export function useChat() {

--- a/apps/beeai-ui/src/modules/run/contexts/hands-off/HandsOffProvider.tsx
+++ b/apps/beeai-ui/src/modules/run/contexts/hands-off/HandsOffProvider.tsx
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import type { TextInput } from '@i-am-bee/beeai-sdk/schemas/text';
+import type { PropsWithChildren } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+
 import type { Agent } from '#modules/agents/api/types.ts';
 import { useRunAgent } from '#modules/run/api/mutations/useRunAgent.tsx';
 import type {
@@ -24,9 +28,7 @@ import type {
 } from '#modules/run/api/types.ts';
 import type { RunStats } from '#modules/run/types.ts';
 import { isNotNull } from '#utils/helpers.ts';
-import type { TextInput } from '@i-am-bee/beeai-sdk/schemas/text';
-import type { PropsWithChildren } from 'react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+
 import { HandsOffContext } from './hands-off-context';
 
 interface Props {

--- a/apps/beeai-ui/src/modules/run/contexts/hands-off/hands-off-context.ts
+++ b/apps/beeai-ui/src/modules/run/contexts/hands-off/hands-off-context.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
+import type { TextInput } from '@i-am-bee/beeai-sdk/schemas/text';
+import { createContext } from 'react';
+
 import type { Agent } from '#modules/agents/api/types.ts';
 import type { TextNotificationLogs } from '#modules/run/api/types.ts';
 import type { RunStats } from '#modules/run/types.ts';
-import type { TextInput } from '@i-am-bee/beeai-sdk/schemas/text';
-import { createContext } from 'react';
 
 export const HandsOffContext = createContext<HandsOffContextValue | undefined>(undefined);
 

--- a/apps/beeai-ui/src/modules/run/contexts/hands-off/index.ts
+++ b/apps/beeai-ui/src/modules/run/contexts/hands-off/index.ts
@@ -15,6 +15,7 @@
  */
 
 import { use } from 'react';
+
 import { HandsOffContext } from './hands-off-context';
 
 export function useHandsOff() {

--- a/apps/beeai-ui/src/modules/run/hands-off/HandsOff.tsx
+++ b/apps/beeai-ui/src/modules/run/hands-off/HandsOff.tsx
@@ -15,6 +15,7 @@
  */
 
 import clsx from 'clsx';
+
 import { AgentHeader } from '../components/AgentHeader';
 import { AgentRunLogs } from '../components/AgentRunLogs';
 import { useHandsOff } from '../contexts/hands-off';

--- a/apps/beeai-ui/src/modules/run/hands-off/HandsOffInput.tsx
+++ b/apps/beeai-ui/src/modules/run/hands-off/HandsOffInput.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import { LineClampText } from '#components/LineClampText/LineClampText.tsx';
 import { PlayFilledAlt } from '@carbon/icons-react';
 import { Button } from '@carbon/react';
 import { useForm } from 'react-hook-form';
+
+import { LineClampText } from '#components/LineClampText/LineClampText.tsx';
+
 import { InputBar } from '../components/InputBar';
 import { useHandsOff } from '../contexts/hands-off';
 import classes from './HandsOffInput.module.scss';

--- a/apps/beeai-ui/src/modules/run/hands-off/HandsOffText.tsx
+++ b/apps/beeai-ui/src/modules/run/hands-off/HandsOffText.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useAutoScroll } from '#hooks/useAutoScroll.ts';
+
 import { AgentOutputBox } from '../components/AgentOutputBox';
 import { useHandsOff } from '../contexts/hands-off';
 

--- a/apps/beeai-ui/src/modules/run/hands-off/HandsOffView.tsx
+++ b/apps/beeai-ui/src/modules/run/hands-off/HandsOffView.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { SplitPanesView } from '#components/SplitPanesView/SplitPanesView.tsx';
 import type { PropsWithChildren } from 'react';
+
+import { SplitPanesView } from '#components/SplitPanesView/SplitPanesView.tsx';
+
 import { useHandsOff } from '../contexts/hands-off';
 import { HandsOffText } from './HandsOffText';
 

--- a/apps/beeai-ui/src/modules/run/hands-off/TaskStatusBar.tsx
+++ b/apps/beeai-ui/src/modules/run/hands-off/TaskStatusBar.tsx
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import { Spinner } from '#components/Spinner/Spinner.tsx';
 import { StopFilled } from '@carbon/icons-react';
 import { Button } from '@carbon/react';
+
+import { Spinner } from '#components/Spinner/Spinner.tsx';
+
 import { ElapsedTime } from '../components/ElapsedTime';
 import { useHandsOff } from '../contexts/hands-off';
 import classes from './TaskStatusBar.module.scss';

--- a/apps/beeai-ui/src/modules/tools/api/queries/useListTools.ts
+++ b/apps/beeai-ui/src/modules/tools/api/queries/useListTools.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { useMCPClient } from '#contexts/MCPClient/index.ts';
 import { useQuery } from '@tanstack/react-query';
+
+import { useMCPClient } from '#contexts/MCPClient/index.ts';
+
 import { toolKeys } from '../keys';
 import type { ListToolsParams } from '../types';
 

--- a/apps/beeai-ui/src/modules/tools/components/ToolIcon.tsx
+++ b/apps/beeai-ui/src/modules/tools/components/ToolIcon.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import Wikipedia from '#svgs/Wikipedia.svg';
 import { IbmWatsonDiscovery, PartlyCloudy, Tools } from '@carbon/icons-react';
+
+import Wikipedia from '#svgs/Wikipedia.svg';
+
 import type { Tool } from '../api/types';
 import classes from './ToolIcon.module.scss';
 

--- a/apps/beeai-ui/src/pages/Settings.tsx
+++ b/apps/beeai-ui/src/pages/Settings.tsx
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
+import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@carbon/react';
+
 import { Container } from '#components/layouts/Container.tsx';
 import { MainContent } from '#components/layouts/MainContent.tsx';
 import { ViewHeader } from '#components/ViewHeader/ViewHeader.tsx';
 import { ViewStack } from '#components/ViewStack/ViewStack.tsx';
 import { EnvsView } from '#modules/envs/components/EnvsView.tsx';
 import { ProvidersView } from '#modules/providers/components/ProvidersView.tsx';
-import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@carbon/react';
 
 export function Settings() {
   return (

--- a/apps/beeai-ui/src/pages/agents/Agent.tsx
+++ b/apps/beeai-ui/src/pages/agents/Agent.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
+import { useNavigate, useParams } from 'react-router';
+
 import { Container } from '#components/layouts/Container.tsx';
 import { MainContent } from '#components/layouts/MainContent.tsx';
 import { AgentDetailView } from '#modules/agents/detail/AgentDetailView.tsx';
 import { routes } from '#utils/router.ts';
-import { useNavigate, useParams } from 'react-router';
 
 type Params = {
   agentName: string;

--- a/apps/beeai-ui/src/pages/run/AgentRunPage.tsx
+++ b/apps/beeai-ui/src/pages/run/AgentRunPage.tsx
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import { useNavigate, useParams } from 'react-router';
+
 import { AgentRun } from '#modules/run/components/AgentRun.tsx';
 import { routes } from '#utils/router.ts';
-import { useNavigate, useParams } from 'react-router';
 
 type Params = {
   agentName: string;

--- a/apps/beeai-ui/src/utils/fadeProps.ts
+++ b/apps/beeai-ui/src/utils/fadeProps.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { motion as carbonMotion, moderate02 } from '@carbon/motion';
+import { moderate02, motion as carbonMotion } from '@carbon/motion';
 import type { Variant } from 'framer-motion';
 
 export function parseCarbonMotion(string: string): number[] {

--- a/apps/beeai-web/eslint.config.mjs
+++ b/apps/beeai-web/eslint.config.mjs
@@ -9,6 +9,15 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
-const eslintConfig = [...compat.extends('next/core-web-vitals', 'next/typescript', 'prettier')];
+const eslintConfig = [
+  ...compat.extends('next/core-web-vitals', 'next/typescript', 'prettier'),
+  ...compat.plugins('simple-import-sort'),
+  {
+    rules: {
+      'simple-import-sort/imports': 'error',
+      'simple-import-sort/exports': 'error',
+    },
+  },
+];
 
 export default eslintConfig;

--- a/apps/beeai-web/package.json
+++ b/apps/beeai-web/package.json
@@ -39,6 +39,7 @@
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-react-hooks": "catalog:",
     "eslint-plugin-react-refresh": "catalog:",
+    "eslint-plugin-simple-import-sort": "catalog:",
     "prettier": "catalog:",
     "sass-embedded": "catalog:",
     "stylelint": "catalog:",

--- a/apps/beeai-web/src/acp/api.ts
+++ b/apps/beeai-web/src/acp/api.ts
@@ -15,6 +15,7 @@
  */
 
 import { cache } from 'react';
+
 import { getAcpClient } from './client';
 
 export const getAgentsList = cache(async () => {

--- a/apps/beeai-web/src/acp/client.ts
+++ b/apps/beeai-web/src/acp/client.ts
@@ -15,11 +15,13 @@
  */
 
 import 'server-only';
+
 import { Client } from '@i-am-bee/acp-sdk/client/index';
-import type { ServerCapabilities } from '@i-am-bee/acp-sdk/types';
 import { SSEClientTransport } from '@i-am-bee/acp-sdk/client/sse';
+import type { ServerCapabilities } from '@i-am-bee/acp-sdk/types';
+import { BodyInit, fetch as undiciFetch } from 'undici';
+
 import { ACP_CLIENT_SERVER_URL } from '@/constants';
-import { fetch as undiciFetch, BodyInit } from 'undici';
 
 export async function getAcpClient() {
   if (!ACP_CLIENT_SERVER_URL) {

--- a/apps/beeai-web/src/app/agents/AgentsFilteredView.tsx
+++ b/apps/beeai-web/src/app/agents/AgentsFilteredView.tsx
@@ -17,6 +17,7 @@
 'use client';
 
 import { type Agent, AgentsFiltersProvider } from '@i-am-bee/beeai-ui';
+
 import { AgentsView } from './AgentsView';
 
 interface Props {

--- a/apps/beeai-web/src/app/agents/AgentsView.tsx
+++ b/apps/beeai-web/src/app/agents/AgentsView.tsx
@@ -15,9 +15,10 @@
  */
 
 'use client';
-import { TransitionLink } from '@/components/TransitionLink/TransitionLink';
-import { type Agent, type AgentsFiltersParams, AgentsFilters, AgentsList, AgentCard } from '@i-am-bee/beeai-ui';
+import { type Agent, AgentCard, AgentsFilters, type AgentsFiltersParams, AgentsList } from '@i-am-bee/beeai-ui';
 import { useFormContext } from 'react-hook-form';
+
+import { TransitionLink } from '@/components/TransitionLink/TransitionLink';
 
 interface Props {
   agents: Agent[] | null;

--- a/apps/beeai-web/src/app/agents/[name]/page.tsx
+++ b/apps/beeai-web/src/app/agents/[name]/page.tsx
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { getAgentsList } from '@/acp/api';
-import { MainContent } from '@/layouts/MainContent';
 import { AgentDetail, Container, TryLocallyButton } from '@i-am-bee/beeai-ui';
 import { notFound } from 'next/navigation';
+
+import { getAgentsList } from '@/acp/api';
+import { MainContent } from '@/layouts/MainContent';
 
 export const revalidate = 600;
 

--- a/apps/beeai-web/src/app/agents/page.tsx
+++ b/apps/beeai-web/src/app/agents/page.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import { Container, ViewStack } from '@i-am-bee/beeai-ui';
+
 import { getAgentsList } from '@/acp/api';
 import { NEXT_PHASE_BUILD } from '@/constants';
 import { MainContent } from '@/layouts/MainContent';
 import { initializeAgentRoutes } from '@/utils/initializeAgentRoutes';
-import { Container, ViewStack } from '@i-am-bee/beeai-ui';
+
 import { AgentsFilteredView } from './AgentsFilteredView';
 
 export const revalidate = 600;

--- a/apps/beeai-web/src/app/api/init-agents/route.ts
+++ b/apps/beeai-web/src/app/api/init-agents/route.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import { initializeAgentRoutes } from '@/utils/initializeAgentRoutes';
 import { NextResponse } from 'next/server';
+
+import { initializeAgentRoutes } from '@/utils/initializeAgentRoutes';
 
 export async function GET() {
   const result = initializeAgentRoutes();

--- a/apps/beeai-web/src/app/get-query-client.ts
+++ b/apps/beeai-web/src/app/get-query-client.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { QueryClient, defaultShouldDehydrateQuery, isServer } from '@tanstack/react-query';
+import { defaultShouldDehydrateQuery, isServer, QueryClient } from '@tanstack/react-query';
 
 function makeQueryClient() {
   return new QueryClient({

--- a/apps/beeai-web/src/app/layout.tsx
+++ b/apps/beeai-web/src/app/layout.tsx
@@ -15,11 +15,14 @@
  */
 
 import '../styles/style.scss';
+
 import type { Metadata } from 'next';
-import AppLayout from '@/layouts/AppLayout';
-import Providers from './providers';
-import { agentRoutesInitialized } from '@/utils/initializeAgentRoutes';
+
 import { AgentRoutesInitializer } from '@/components/AgentRoutesInitializer/AgentRoutesInitializer';
+import AppLayout from '@/layouts/AppLayout';
+import { agentRoutesInitialized } from '@/utils/initializeAgentRoutes';
+
+import Providers from './providers';
 
 const darkModeScript = `
 (() => {

--- a/apps/beeai-web/src/app/page.tsx
+++ b/apps/beeai-web/src/app/page.tsx
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { MainContent } from '@/layouts/MainContent';
 import { GettingStarted, type VideoBeeAIProps } from '@i-am-bee/beeai-ui';
+
+import { MainContent } from '@/layouts/MainContent';
+
 import poster from '../images/VideoBeeAIPoster.webp';
 
 export default function Home() {

--- a/apps/beeai-web/src/app/providers.tsx
+++ b/apps/beeai-web/src/app/providers.tsx
@@ -15,11 +15,13 @@
  */
 
 'use client';
-import { ProgressBarProvider } from '@/contexts/ProgressBar/ProgressBarProvider';
-import { RouteTransitionProvider } from '@/contexts/TransitionContext/RouteTransitionProvider';
 import { ThemeProvider } from '@i-am-bee/beeai-ui';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { PropsWithChildren } from 'react';
+
+import { ProgressBarProvider } from '@/contexts/ProgressBar/ProgressBarProvider';
+import { RouteTransitionProvider } from '@/contexts/TransitionContext/RouteTransitionProvider';
+
 import { getQueryClient } from './get-query-client';
 
 export default function Providers({ children }: PropsWithChildren) {

--- a/apps/beeai-web/src/components/AgentRoutesInitializer/AgentRoutesInitializer.ts
+++ b/apps/beeai-web/src/components/AgentRoutesInitializer/AgentRoutesInitializer.ts
@@ -15,9 +15,10 @@
  */
 
 'use client';
-import { InitAgentRoutesResponse } from '@/app/api/init-agents/route';
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
+
+import { InitAgentRoutesResponse } from '@/app/api/init-agents/route';
 
 interface Props {
   initialized: boolean;

--- a/apps/beeai-web/src/components/TransitionLink/TransitionLink.tsx
+++ b/apps/beeai-web/src/components/TransitionLink/TransitionLink.tsx
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { useRouteTransition } from '@/contexts/TransitionContext';
 import Link, { LinkProps } from 'next/link';
 import { PropsWithChildren } from 'react';
+
+import { useRouteTransition } from '@/contexts/TransitionContext';
 
 interface Props extends LinkProps {
   className?: string;

--- a/apps/beeai-web/src/contexts/ProgressBar/ProgressBarProvider.tsx
+++ b/apps/beeai-web/src/contexts/ProgressBar/ProgressBarProvider.tsx
@@ -16,8 +16,8 @@
 
 'use client';
 
-import { PropsWithChildren } from 'react';
 import { ProgressProvider } from '@bprogress/next/app';
+import { PropsWithChildren } from 'react';
 
 export function ProgressBarProvider({ children }: PropsWithChildren) {
   return (

--- a/apps/beeai-web/src/contexts/TransitionContext/RouteTransitionProvider.tsx
+++ b/apps/beeai-web/src/contexts/TransitionContext/RouteTransitionProvider.tsx
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { PropsWithChildren, useCallback, useEffect, useMemo, useRef } from 'react';
-import { RouteTransitionContext } from './context';
-import { usePathname } from 'next/navigation';
-import { NavigateOptions } from 'next/dist/shared/lib/app-router-context.shared-runtime';
-import { moderate02 } from '@carbon/motion';
 import { useRouter } from '@bprogress/next/app';
+import { moderate02 } from '@carbon/motion';
+import { NavigateOptions } from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import { usePathname } from 'next/navigation';
+import { PropsWithChildren, useCallback, useEffect, useMemo, useRef } from 'react';
+
+import { RouteTransitionContext } from './context';
 
 export function RouteTransitionProvider({ children }: PropsWithChildren) {
   const router = useRouter();

--- a/apps/beeai-web/src/contexts/TransitionContext/index.ts
+++ b/apps/beeai-web/src/contexts/TransitionContext/index.ts
@@ -15,6 +15,7 @@
  */
 
 import { use } from 'react';
+
 import { RouteTransitionContext } from './context';
 
 export function useRouteTransition() {

--- a/apps/beeai-web/src/layouts/AppLayout.tsx
+++ b/apps/beeai-web/src/layouts/AppLayout.tsx
@@ -16,6 +16,7 @@
 
 import { AppHeader, GitHubLink } from '@i-am-bee/beeai-ui';
 import type { PropsWithChildren } from 'react';
+
 import classes from './AppLayout.module.scss';
 import { Navigation } from './Navigation';
 

--- a/apps/beeai-web/src/layouts/Navigation.tsx
+++ b/apps/beeai-web/src/layouts/Navigation.tsx
@@ -16,11 +16,12 @@
 
 'use client';
 
-import { TransitionLink } from '@/components/TransitionLink/TransitionLink';
 import { ArrowUpRight } from '@carbon/icons-react';
 import { DOCUMENTATION_LINK, MainNav } from '@i-am-bee/beeai-ui';
 import { usePathname } from 'next/navigation';
 import { ComponentType } from 'react';
+
+import { TransitionLink } from '@/components/TransitionLink/TransitionLink';
 
 export function Navigation() {
   const pathname = usePathname();

--- a/apps/beeai-web/src/utils/initializeAgentRoutes.ts
+++ b/apps/beeai-web/src/utils/initializeAgentRoutes.ts
@@ -15,8 +15,10 @@
  */
 
 import { revalidatePath } from 'next/cache';
-import { routeDefinitions } from './router';
+
 import { NEXT_PHASE_BUILD } from '@/constants';
+
+import { routeDefinitions } from './router';
 
 export let agentRoutesInitialized = false;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     eslint-plugin-react-refresh:
       specifier: ^0.4.16
       version: 0.4.19
+    eslint-plugin-simple-import-sort:
+      specifier: ^12.1.1
+      version: 12.1.1
     globals:
       specifier: ^16.0.0
       version: 16.0.0
@@ -213,6 +216,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: 'catalog:'
         version: 0.4.19(eslint@9.23.0)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 12.1.1(eslint@9.23.0)
       globals:
         specifier: 'catalog:'
         version: 16.0.0
@@ -325,6 +331,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: 'catalog:'
         version: 0.4.19(eslint@9.23.0)
+      eslint-plugin-simple-import-sort:
+        specifier: 'catalog:'
+        version: 12.1.1(eslint@9.23.0)
       prettier:
         specifier: 'catalog:'
         version: 3.5.3
@@ -3977,6 +3986,11 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-plugin-simple-import-sort@12.1.1:
+    resolution: {integrity: sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==}
+    peerDependencies:
+      eslint: '>=5.0.0'
 
   eslint-scope@8.2.0:
     resolution: {integrity: sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==}
@@ -11361,6 +11375,10 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
+
+  eslint-plugin-simple-import-sort@12.1.1(eslint@9.23.0):
+    dependencies:
+      eslint: 9.23.0
 
   eslint-scope@8.2.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ catalog:
   eslint: "^9.23.0"
   eslint-plugin-react-hooks: "^5.2.0"
   eslint-plugin-react-refresh: "^0.4.16"
+  eslint-plugin-simple-import-sort: "^12.1.1"
   globals: "^16.0.0"
   prettier: "^3.5.3"
   sass-embedded: "^1.86.0"


### PR DESCRIPTION
I was originally going to add https://www.npmjs.com/package/eslint-plugin-import, but that actually has more rules than just sorting imports and didn't work properly with our setup, so I ended up choosing https://www.npmjs.com/package/eslint-plugin-simple-import-sort, which does the sorting and nothing else and just works.

The motivation for adding the eslint rule for sorting imports/exports is that the lack of this rule was causing a lot of reordering of imports between files, which just polluted the commits.