### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [IBM Cloud Support](https://www.ibm.com/cloud/support).
+reported by contacting the project team at [deepsearch-core@zurich.ibm.com](mailto:deepsearch-core@zurich.ibm.com).
 All complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -67,8 +67,8 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,
+ available at [https://www.contributor-covenant.org/version/2/0/code_of_conduct.html](https://www.contributor-covenant.org/version/2/0/code_of_conduct/)
 
 [homepage]: https://www.contributor-covenant.org
 


### PR DESCRIPTION
Fixes #847: Updates Code of Conduct to Contributor Covenant v2.0 to align with bee-framework and Community section of i-am-bee org and sets enforcement contact to deepsearch-core@zurich.ibm.com instead of IBM Cloud Support. 