### PR TITLE
fix(docs): replace Context with RunContext

### DIFF
--- a/docs/build-agents/agent-details.mdx
+++ b/docs/build-agents/agent-details.mdx
@@ -23,7 +23,7 @@ from a2a.types import (
     Message,
 )
 from beeai_sdk.server import Server
-from beeai_sdk.server.context import Context
+from beeai_sdk.server.context import RunContext
 from beeai_sdk.a2a.extensions import AgentDetail, AgentDetailContributor, AgentDetailTool
 
 server = Server()
@@ -59,7 +59,7 @@ server = Server()
         ]
     )
 )
-async def example_agent(input: Message, context: Context):
+async def example_agent(input: Message, context: RunContext):
     """An example agent with detailed configuration"""
     yield "Hello World!"
 

--- a/docs/build-agents/gui-components.mdx
+++ b/docs/build-agents/gui-components.mdx
@@ -42,14 +42,14 @@ from a2a.types import (
     Message,
 )
 from beeai_sdk.server import Server
-from beeai_sdk.server.context import Context
+from beeai_sdk.server.context import RunContext
 from beeai_sdk.a2a.extensions import TrajectoryExtensionServer, TrajectoryExtensionSpec
 
 server = Server()
 
 @server.agent()
 async def example_agent(
-    input: Message, context: Context, trajectory: Annotated[TrajectoryExtensionServer, TrajectoryExtensionSpec()]
+    input: Message, context: RunContext, trajectory: Annotated[TrajectoryExtensionServer, TrajectoryExtensionSpec()]
 ):
     """Polite agent that greets the user"""
 
@@ -85,7 +85,7 @@ from beeai_sdk.a2a.extensions import TrajectoryExtensionServer, TrajectoryExtens
 
 @server.agent()
 async def example_agent(
-    input: Message, context: Context, trajectory: Annotated[TrajectoryExtensionServer, TrajectoryExtensionSpec()]
+    input: Message, context: RunContext, trajectory: Annotated[TrajectoryExtensionServer, TrajectoryExtensionSpec()]
 ):
 ```
 
@@ -117,7 +117,7 @@ from beeai_sdk.a2a.extensions import CitationExtensionServer, CitationExtensionS
 
 @server.agent()
 async def example_agent(
-    input: Message, context: Context, citation: Annotated[CitationExtensionServer, CitationExtensionSpec()]
+    input: Message, context: RunContext, citation: Annotated[CitationExtensionServer, CitationExtensionSpec()]
 ):
 ```
 

--- a/docs/introduction/start-building-agents.mdx
+++ b/docs/introduction/start-building-agents.mdx
@@ -75,13 +75,13 @@ from a2a.types import (
 )
 from a2a.utils.message import get_message_text
 from beeai_sdk.server import Server
-from beeai_sdk.server.context import Context
+from beeai_sdk.server.context import RunContext
 from beeai_sdk.a2a.types import AgentMessage
 
 server = Server()
 
 @server.agent()
-async def example_agent(input: Message, context: Context):
+async def example_agent(input: Message, context: RunContext):
     """Polite agent that greets the user"""
     hello_template: str = os.getenv("HELLO_TEMPLATE", "Ciao %s!")
     yield AgentMessage(text=hello_template % get_message_text(input))
@@ -114,7 +114,7 @@ Write a docstring for the function; it will be extracted and shown as the agentâ
 
 <Step title="Understand the function arguments">
 - **First argument:** an [A2A `Message`](https://a2a-protocol.org/latest/specification/#64-message-object).
-- **Second argument:** a `Context` object with run details (e.g., `task_id`, `context_id`).
+- **Second argument:** a `RunContext` object with run details (e.g., `task_id`, `context_id`).
 </Step>
 
 <Step title="Extract text from Message">


### PR DESCRIPTION
This PR updates the documentation examples by replacing usages of Context with RunContext. The change ensures the docs align with the current API and usage patterns for agent functions.

Fixes the [issue](https://github.com/i-am-bee/beeai-platform/issues/1383) raised by @sandijean90 

### ✅ Why this change is needed

- The documentation previously showed Context in code samples, which no longer matches the actual type used in the agent APIs.
- Updating to RunContext improves accuracy of the docs, reduces onboarding friction, and helps maintain consistency with the codebase.

### 📝 What’s changed

- All code snippets in the docs (in the “Agent Details” example and other sections) have been updated to replace Context with RunContext.
- The function signatures and parameter names in the examples have been adjusted accordingly to reflect the correct type.

### 🚀 Impact

- Documentation-only change — no runtime code logic is altered.
- Improves developer experience by aligning docs with actual API usage.
- Reduces potential support issues/questions stemming from outdated examples.