### PR TITLE
feat(sdk): add server url

### DIFF
--- a/apps/agentstack-sdk-py/src/agentstack_sdk/server/server.py
+++ b/apps/agentstack-sdk-py/src/agentstack_sdk/server/server.py
@@ -139,7 +139,8 @@ class Server:
 
         context_store = context_store or InMemoryContextStore()
         self._agent = self._agent_factory(context_store)
-        self._agent.card.url = url.rstrip("/") if url else f"http://{host}:{port}"
+        card_url = url and url.strip()
+        self._agent.card.url = card_url.rstrip("/") if card_url else f"http://{host}:{port}"
 
         self._self_registration_client = (
             self_registration_client_factory() if self_registration_client_factory else None


### PR DESCRIPTION
## 🎯 Summary
This PR adds support for configuring a public-facing server URL in `/.well-known/agent-card.json`.
Previously, deployed agents exposed internal or loopback (127.0.0.1) addresses in their agent card, which made them inaccessible from external clients or environments.

## 📌 Why this change is needed

Deployed agents currently advertise interfaces like:
```json
"additionalInterfaces": [
    {
        "transport": "HTTP+JSON",
        "url": "http://127.0.0.1:8000/"
    },
    {
        "transport": "JSONRPC",
        "url": "http://127.0.0.1:8000/jsonrpc/"
    }
],
"url": "http://127.0.0.1:8000/jsonrpc/",
```

These URLs are only reachable within the host environment.
To enable SDKs or remote clients to communicate with deployed agents, we need a configurable external server URL that accurately reflects the public endpoint.

## 📝 Changes
- **Added `url` parameter**: Allows custom URL configuration for the agent card instead of auto-generating from host:port
- **Updated agent card URL logic**: Uses custom URL when provided, falls back to `http://{host}:{port}` if not specified

## 🔧 Technical Details
**File Modified**: `apps/agentstack-sdk-py/src/agentstack_sdk/server/server.py`

### New Parameters:
1. `url: str | None = None` - Optional custom URL for the agent card

### Behavior:
- When `url` is provided, it's used for the agent card URL (trailing slashes are stripped)
- When `url` is `None`, the URL defaults to `http://{host}:{port}` (existing behavior)

## 💡 Use Cases
- **Custom URL**: Useful when the server is behind a proxy, load balancer, or has a custom domain

## ✅ Testing
- [ ] Verify default behavior (no URL provided) works as before
- [ ] Test custom URL configuration
- [ ] Validate URL trailing slash handling
- [ ] Confirm worker healthcheck timeout is properly applied

## 🔄 Backwards Compatibility
✅ Fully backwards compatible - both new parameters are optional with sensible defaults

## Example with IBM Code Engine

```py
import os
from dotenv import load_dotenv
from a2a.types import Message
from agentstack_sdk.server import Server
from agentstack_sdk.server.context import RunContext
from agentstack_sdk.a2a.types import AgentMessage

load_dotenv()

server = Server()

@server.agent(name="Hello World Agent")
async def hello_world_agent(input: Message, context: RunContext):
    """Polite agent that greets the user"""

    return AgentMessage(text="Hello World!")

def run():
    host = os.getenv("HOST", "127.0.0.1")
    port = int(os.getenv("PORT", 8000))
    url = f"http://{host}:{port}"

    ce_app = os.getenv("CE_APP")
    if ce_app:
        ce_subdomain = os.getenv("CE_SUBDOMAIN", "")
        ce_domain = os.getenv("CE_DOMAIN", "")
        url = f"https://{ce_app}.{ce_subdomain}.{ce_domain}".rstrip(".")

    server.run(host=host, port=port, url=url)

if __name__ == "__main__":
    run()
```