### PR TITLE
fix(ui): display agent-generated images in response markdown

### DIFF
--- a/apps/agentstack-ui/src/components/MarkdownContent/utils.ts
+++ b/apps/agentstack-ui/src/components/MarkdownContent/utils.ts
@@ -5,9 +5,17 @@
 
 import { defaultUrlTransform } from 'react-markdown';
 
+import { PLATFORM_FILE_CONTENT_URL_BASE } from '#api/a2a/constants.ts';
+import { getFileIdFromFilePlatformUrl } from '#api/a2a/utils.ts';
+import { getFileContentUrl } from '#modules/files/utils.ts';
+
 export function urlTransform(value: string): string {
   if (value.startsWith('data:image/')) {
     return value;
+  }
+
+  if (value.startsWith(PLATFORM_FILE_CONTENT_URL_BASE)) {
+    return getFileContentUrl(getFileIdFromFilePlatformUrl(value));
   }
 
   return defaultUrlTransform(value);


### PR DESCRIPTION
## Summary
Fixes the display of agent-generated images in response markdown by rewriting their URIs to load the content through the API using the `/api/v1/files/{file_id}/content endpoint`.

## Linked Issues
Resolves #1592


## Documentation
- [x] No Docs Needed: minor UI fix