### PR TITLE
fix(tests): use self-hosted runner for e2e tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -19,7 +19,7 @@ on:
       - 'helm/**'
 jobs:
   e2e-test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - name: "Set up Lima"


### PR DESCRIPTION
## Summary
Github runners continuously run out of disk space or into some other limitation with our e2e pipeline

## Documentation
- [x] No Docs Needed: