### PR TITLE
feat(cli): streamline build commands, switch to server-side

### DIFF
--- a/apps/agentstack-cli/src/agentstack_cli/__init__.py
+++ b/apps/agentstack-cli/src/agentstack_cli/__init__.py
@@ -33,13 +33,14 @@ Usage: agentstack [OPTIONS] COMMAND [ARGS]...
 ╰────────────────────────────────────────────────────────────────────────────╯
 
 ╭─ Agent Management ─────────────────────────────────────────────────────────╮
-│ add                               Install an agent (Docker, GitHub, local) │
+│ add                               Install an agent (Docker, GitHub)        │
 │ remove                            Uninstall an agent                       │
+│ update                            Update an agent                          │
 │ info                              Show agent details                       │
 │ logs                              Stream agent execution logs              │
-│ build                             Build an agent container image           │
 │ env                               Manage agent environment variables       │
-│ server-side-build [EXPERIMENTAL]  Build agents remotely                    │
+│ build                             Build an agent remotely                  │
+│ client-side-build                 Build an agent container image locally   │
 ╰────────────────────────────────────────────────────────────────────────────╯
 
 ╭─ Platform & Configuration ─────────────────────────────────────────────────╮
@@ -92,7 +93,9 @@ app.add_typer(agent_alias, name="", no_args_is_help=True)
 
 
 @app.command("version")
-async def version(verbose: typing.Annotated[bool, typer.Option("-v", help="Show verbose output")] = False):
+async def version(
+    verbose: typing.Annotated[bool, typer.Option("-v", "--verbose", help="Show verbose output")] = False,
+):
     """Print version of the Agent Stack CLI."""
     import agentstack_cli.commands.self
 

--- a/apps/agentstack-cli/src/agentstack_cli/commands/model.py
+++ b/apps/agentstack-cli/src/agentstack_cli/commands/model.py
@@ -413,7 +413,7 @@ async def _reset_configuration(existing_providers: list[ModelProvider] | None = 
 @app.command("setup")
 async def setup(
     use_true_localhost: typing.Annotated[bool, typer.Option(hidden=True)] = False,
-    verbose: typing.Annotated[bool, typer.Option("-v")] = False,
+    verbose: typing.Annotated[bool, typer.Option("-v", "--verbose", help="Show verbose output")] = False,
 ):
     """Interactive setup for LLM and embedding provider environment variables"""
     announce_server_action("Configuring model providers for")

--- a/apps/agentstack-cli/src/agentstack_cli/commands/platform/__init__.py
+++ b/apps/agentstack-cli/src/agentstack_cli/commands/platform/__init__.py
@@ -72,7 +72,7 @@ async def start(
         pathlib.Path | None, typer.Option("-f", help="Set Helm chart values using yaml values file")
     ] = None,
     vm_name: typing.Annotated[str, typer.Option(hidden=True)] = "agentstack",
-    verbose: typing.Annotated[bool, typer.Option("-v", help="Show verbose output")] = False,
+    verbose: typing.Annotated[bool, typer.Option("-v", "--verbose", help="Show verbose output")] = False,
 ):
     """Start Agent Stack platform."""
     import agentstack_cli.commands.server
@@ -127,7 +127,7 @@ async def start(
 @app.command("stop")
 async def stop(
     vm_name: typing.Annotated[str, typer.Option(hidden=True)] = "agentstack",
-    verbose: typing.Annotated[bool, typer.Option("-v", help="Show verbose output")] = False,
+    verbose: typing.Annotated[bool, typer.Option("-v", "--verbose", help="Show verbose output")] = False,
 ):
     """Stop Agent Stack platform."""
     with verbosity(verbose):
@@ -142,7 +142,7 @@ async def stop(
 @app.command("delete")
 async def delete(
     vm_name: typing.Annotated[str, typer.Option(hidden=True)] = "agentstack",
-    verbose: typing.Annotated[bool, typer.Option("-v", help="Show verbose output")] = False,
+    verbose: typing.Annotated[bool, typer.Option("-v", "--verbose", help="Show verbose output")] = False,
 ):
     """Delete Agent Stack platform."""
     with verbosity(verbose):
@@ -155,7 +155,7 @@ async def delete(
 async def import_image_cmd(
     tag: typing.Annotated[str, typer.Argument(help="Docker image tag to import")],
     vm_name: typing.Annotated[str, typer.Option(hidden=True)] = "agentstack",
-    verbose: typing.Annotated[bool, typer.Option("-v", help="Show verbose output")] = False,
+    verbose: typing.Annotated[bool, typer.Option("-v", "--verbose", help="Show verbose output")] = False,
 ):
     """Import a local docker image into the Agent Stack platform."""
     with verbosity(verbose):
@@ -170,7 +170,7 @@ async def import_image_cmd(
 async def exec_cmd(
     command: typing.Annotated[list[str] | None, typer.Argument()] = None,
     vm_name: typing.Annotated[str, typer.Option(hidden=True)] = "agentstack",
-    verbose: typing.Annotated[bool, typer.Option("-v", help="Show verbose output")] = False,
+    verbose: typing.Annotated[bool, typer.Option("-v", "--verbose", help="Show verbose output")] = False,
 ):
     """For debugging -- execute a command inside the Agent Stack platform VM."""
     with verbosity(verbose, show_success_status=False):

--- a/apps/agentstack-cli/src/agentstack_cli/commands/platform/base_driver.py
+++ b/apps/agentstack-cli/src/agentstack_cli/commands/platform/base_driver.py
@@ -117,6 +117,8 @@ class BaseDriver(abc.ABC):
                 "generateConversationTitle": False,  # TODO: enable when UI implementation is ready
                 "uiLocalSetup": True,
             },
+            "providerBuilds": {"enabled": True},
+            "localDockerRegistry": {"enabled": True},
             "auth": {"enabled": False},
         }
         if values_file:

--- a/apps/agentstack-cli/src/agentstack_cli/commands/self.py
+++ b/apps/agentstack-cli/src/agentstack_cli/commands/self.py
@@ -40,7 +40,9 @@ def _path() -> str:
 
 
 @app.command("version")
-async def version(verbose: typing.Annotated[bool, typer.Option("-v", help="Show verbose output")] = False):
+async def version(
+    verbose: typing.Annotated[bool, typer.Option("-v", "--verbose", help="Show verbose output")] = False,
+):
     """Print version of the Agent Stack CLI."""
     with verbosity(verbose=verbose):
         cli_version = importlib.metadata.version("agentstack-cli")
@@ -78,7 +80,7 @@ async def version(verbose: typing.Annotated[bool, typer.Option("-v", help="Show 
 
 @app.command("install")
 async def install(
-    verbose: typing.Annotated[bool, typer.Option("-v", help="Show verbose output")] = False,
+    verbose: typing.Annotated[bool, typer.Option("-v", "--verbose", help="Show verbose output")] = False,
 ):
     """Install Agent Stack platform pre-requisites."""
     with verbosity(verbose=verbose):
@@ -171,7 +173,9 @@ async def install(
 
 
 @app.command("upgrade")
-async def upgrade(verbose: typing.Annotated[bool, typer.Option("-v", help="Show verbose output")] = False):
+async def upgrade(
+    verbose: typing.Annotated[bool, typer.Option("-v", "--verbose", help="Show verbose output")] = False,
+):
     """Upgrade Agent Stack CLI and Platform to the latest version."""
     if not shutil.which("uv", path=_path()):
         console.error("Can't self-upgrade because 'uv' was not found.")
@@ -189,7 +193,7 @@ async def upgrade(verbose: typing.Annotated[bool, typer.Option("-v", help="Show 
 
 @app.command("uninstall")
 async def uninstall(
-    verbose: typing.Annotated[bool, typer.Option("-v", help="Show verbose output")] = False,
+    verbose: typing.Annotated[bool, typer.Option("-v", "--verbose", help="Show verbose output")] = False,
 ):
     """Uninstall Agent Stack CLI and Platform."""
     if not shutil.which("uv", path=_path()):

--- a/apps/agentstack-cli/src/agentstack_cli/utils.py
+++ b/apps/agentstack-cli/src/agentstack_cli/utils.py
@@ -26,7 +26,7 @@ from jsf import JSF
 from prompt_toolkit import PromptSession
 from prompt_toolkit.shortcuts import CompleteStyle
 from pydantic import BaseModel
-from rich.console import Capture
+from rich.console import Capture, Console
 from rich.text import Text
 
 from agentstack_cli.configuration import Configuration
@@ -296,7 +296,7 @@ def verbosity(verbose: bool, show_success_status: bool = True):
         SHOW_SUCCESS_STATUS.reset(token_command_status)
 
 
-def print_log(line, ansi_mode=False):
+def print_log(line, ansi_mode=False, out_console: Console | None = None):
     if "error" in line:
 
         class CustomError(Exception): ...
@@ -309,6 +309,6 @@ def print_log(line, ansi_mode=False):
         return Text.from_ansi(text) if ansi_mode else text
 
     if line["stream"] == "stderr":
-        err_console.print(decode(line["message"]))
+        (out_console or err_console).print(decode(line["message"]))
     elif line["stream"] == "stdout":
-        console.print(decode(line["message"]))
+        (out_console or console).print(decode(line["message"]))

--- a/apps/agentstack-server/src/agentstack_server/exceptions.py
+++ b/apps/agentstack-server/src/agentstack_server/exceptions.py
@@ -69,6 +69,11 @@ class ForbiddenUpdateError(PlatformError):
         super().__init__("Insufficient permissions", status_code)
 
 
+class InvalidProviderUpgradeError(PlatformError):
+    def __init__(self, message: str, status_code: int = status.HTTP_409_CONFLICT):
+        super().__init__(message, status_code)
+
+
 class InvalidProviderCallError(PlatformError): ...
 
 
@@ -88,7 +93,9 @@ class StorageCapacityExceededError(PlatformError):
 
 
 class ModelLoadFailedError(PlatformError):
-    def __init__(self, provider: ModelProvider, exception: HTTPError, status_code: int = status.HTTP_400_BAD_REQUEST):
+    def __init__(
+        self, provider: ModelProvider, exception: HTTPError, status_code: int = status.HTTP_424_FAILED_DEPENDENCY
+    ):
         from agentstack_server.application import extract_messages
 
         super().__init__(
@@ -118,7 +125,7 @@ class DuplicateEntityError(PlatformError):
         entity: str,
         field: str = "name",
         value: str | UUID | None = None,
-        status_code: int = status.HTTP_400_BAD_REQUEST,
+        status_code: int = status.HTTP_409_CONFLICT,
     ):
         self.entity = entity
         self.field = field
@@ -130,7 +137,7 @@ class DuplicateEntityError(PlatformError):
 
 
 class BuildAlreadyFinishedError(PlatformError):
-    def __init__(self, platform_build_id: UUID, state: "BuildState", status_code: int = status.HTTP_400_BAD_REQUEST):
+    def __init__(self, platform_build_id: UUID, state: "BuildState", status_code: int = status.HTTP_409_CONFLICT):
         super().__init__(
             message=f"Build with ID {platform_build_id} already finished in state: {state}",
             status_code=status_code,

--- a/apps/agentstack-server/src/agentstack_server/infrastructure/kubernetes/default_templates/build-provider-job.yaml
+++ b/apps/agentstack-server/src/agentstack_server/infrastructure/kubernetes/default_templates/build-provider-job.yaml
@@ -11,6 +11,7 @@ spec:
   ttlSecondsAfterFinished: 60
   template:
     spec:
+      terminationGracePeriodSeconds: 3
       imagePullSecrets:
         - name: agentstack-registry-secret
       securityContext:
@@ -30,6 +31,7 @@ spec:
           args:
             - -c
             - |
+              set -eo pipefail
               echo "Cloning repository..."
               # Check if GitHub token is available for this host
               if [ -n "$GIT_TOKEN" ]; then
@@ -132,6 +134,7 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -eo pipefail
               # Extract agent manifest
               for i in $(seq 1 30); do
                 if nc -z 127.0.0.1 8000; then

--- a/apps/agentstack-server/src/agentstack_server/infrastructure/kubernetes/provider_build_manager.py
+++ b/apps/agentstack-server/src/agentstack_server/infrastructure/kubernetes/provider_build_manager.py
@@ -152,7 +152,7 @@ class KubernetesProviderBuildManager(IProviderBuildManager):
         async with self.api() as api:
             try:
                 job = await Job.get(name=self._get_k8s_name(provider_build_id), api=api)
-                await job.delete(grace_period=int(grace_period.total_seconds()))
+                await job.delete(grace_period=int(grace_period.total_seconds()), propagation_policy="Background")
             except kr8s.NotFoundError as e:
                 raise EntityNotFoundError("build_provider_job", provider_build_id) from e
 

--- a/apps/agentstack-server/src/agentstack_server/service_layer/services/providers.py
+++ b/apps/agentstack-server/src/agentstack_server/service_layer/services/providers.py
@@ -28,7 +28,7 @@ from agentstack_server.domain.models.provider import (
 from agentstack_server.domain.models.registry import RegistryLocation
 from agentstack_server.domain.models.user import User, UserRole
 from agentstack_server.domain.repositories.env import EnvStoreEntity
-from agentstack_server.exceptions import ManifestLoadError
+from agentstack_server.exceptions import InvalidProviderUpgradeError, ManifestLoadError
 from agentstack_server.service_layer.deployment_manager import (
     IProviderDeploymentManager,
 )
@@ -118,7 +118,7 @@ class ProviderService:
         async with self._uow() as uow:
             provider = await uow.providers.get(provider_id=provider_id, user_id=user_id)
             if provider.registry and not allow_registry_update:
-                raise ValueError("Cannot update provider added from registry")
+                raise InvalidProviderUpgradeError("Cannot update provider added from registry")
             old_variables = (
                 await uow.env.get_all(
                     parent_entity=EnvStoreEntity.PROVIDER,

--- a/apps/agentstack-server/tasks.toml
+++ b/apps/agentstack-server/tasks.toml
@@ -221,8 +221,6 @@ run = """
 {{ mise_bin }} run agentstack-server:dev:start \
     --vm-name=agentstack-local-test \
     --set externalRegistries=null \
-    --set providerBuilds.enabled=true \
-    --set localDockerRegistry.enabled=true \
     {{arg(name="cli-args", var=true, default="--")}}
 """
 
@@ -268,9 +266,7 @@ curl http://localhost:8333 >/dev/null 2>&1 && echo "Another instance at localhos
     --set auth.basic.enabled="true" \
     --set auth.basic.adminPassword="test-password" \
     --set auth.jwtSecretKey="test-secret-key" \
-    --set docling.enabled=true \
-    --set providerBuilds.enabled=true \
-    --set localDockerRegistry.enabled=true
+    --set docling.enabled=true
 
 
 eval "$( {{ mise_bin }} run agentstack:shell --vm-name="$VM_NAME" )"

--- a/apps/agentstack-server/template.env
+++ b/apps/agentstack-server/template.env
@@ -20,8 +20,7 @@ TEXT_EXTRACTION__ENABLED=true
 # Custom agent registry file
 # AGENT_REGISTRY__LOCATIONS__FILE="file:///Users/radek/Code/agentstack/instance/local_registry.yaml"
 
-# For debugging provider builds, requires starting platform with
-# --set providerBuilds.enabled=true --set localDockerRegistry.enabled=true
+# For debugging provider builds
 OCI_REGISTRY__AGENTSTACK-REGISTRY-SVC.DEFAULT:5001__USERNAME=dummy
 OCI_REGISTRY__AGENTSTACK-REGISTRY-SVC.DEFAULT:5001__PASSWORD=dummy
 OCI_REGISTRY__AGENTSTACK-REGISTRY-SVC.DEFAULT:5001__INSECURE=true

--- a/docs/guides/cli-reference.mdx
+++ b/docs/guides/cli-reference.mdx
@@ -83,16 +83,16 @@ agentstack add <location>
 agentstack add ghcr.io/i-am-bee/agentstack/agents/chat:latest
 
 # From GitHub repository
-agentstack add "https://github.com/user/repo"
+agentstack add "https://github.com/user/repo.git"
 
 # From GitHub with version tag
-agentstack add "https://github.com/user/repo#v1.0.0"
+agentstack add "https://github.com/user/repo.git@v1.0.0"
 
 # From GitHub with specific path
-agentstack add "https://github.com/user/repo#:agents/my-agent"
+agentstack add "https://github.com/user/repo.git#path=/agents/my-agent"
 
-# From local directory (builds Docker image)
-agentstack add ./my-agent-directory
+# From GitHub with specific dockerfile location within the repository
+agentstack add --dockerfile /my-agent/Dockerfile "https://github.com/user/repo.git#path=/agents/my-agent"
 ```
 
 ### remove
@@ -101,6 +101,32 @@ Remove an agent from your environment:
 
 ```bash
 agentstack remove <agent-name>
+```
+
+### update
+
+Update an existing agent to a new version:
+
+```bash
+agentstack update <agent-name> <location>
+```
+
+**Location formats:**
+```bash
+# From Docker image
+agentstack update my-agent ghcr.io/i-am-bee/agentstack/agents/chat:latest
+
+# From GitHub repository
+agentstack update my-agent "https://github.com/user/repo.git"
+
+# From GitHub with version tag
+agentstack update my-agent "https://github.com/user/repo.git@v1.0.0"
+
+# From GitHub with specific path
+agentstack update my-agent "https://github.com/user/repo.git#path=/agents/my-agent"
+
+# From GitHub with specific dockerfile location within the repository
+agentstack update my-agent --dockerfile /my-agent/Dockerfile "https://github.com/user/repo.git#path=/agents/my-agent"
 ```
 
 ### logs
@@ -115,62 +141,73 @@ Displays the agent's log output and continues streaming new logs as they are gen
 
 ### build
 
-Build an agent from a local directory or GitHub repository:
+Build an agent from a GitHub repository:
 
-<Note>
-Requires Docker running
-</Note>
+This command clones the repository and builds the agent image on the platform. You will get an image ID
+which you can use to add the agent to your environment.
 
 ```
-agentstack build [context]
+agentstack build <github-repository-url>
+```
+
+**Examples:**
+```bash
+# Build from GitHub repository
+agentstack build https://github.com/org/repo.git
+
+# Build specific version
+agentstack build https://github.com/org/repo.git@release-0.0.1
+
+# Specify Dockerfile location (useful for monorepos)
+agentstack build --dockerfile=./path/to/Dockerfile https://github.com/org/repo.git@release-0.0.1
+
+# Specify docker context location
+agentstack build https://github.com/org/repo.git@release-0.0.1#path=/path/to/context
 ```
 
 **Arguments:**
-- `context`: Path to build context (default: current directory)
+- `github-repository-url`: GitHub repository URL
 
 **Options:**
 - `--dockerfile <path>`: Use custom dockerfile path
-- `--tag <name>`: Docker tag for the agent
-- `--multi-platform`: Build for multiple platforms
-- `--push`: Push the image to the target registry
-- `--import/--no-import`: Import the image into Agent Stack (default: true)
+
+### Client-side-build
+Build an agent from a local directory. This is useful for CI/CD, multi-platform image build
+or local push of agent image to registry.
+
+<Note>
+    Requires Docker running
+</Note>
+
+```bash
+agentstack client-side-build [OPTIONS] <docker-context>
+```
+
 
 **Examples:**
 ```bash
 # Build from current directory
-agentstack build .
+agentstack client-side-build .
 
 # Build with custom tag
-agentstack build . --tag my-agent:latest
+agentstack client-side-build . --tag my-agent:latest
 
 # Build without importing to platform
-agentstack build . --no-import
-
-# Build from GitHub URL
-agentstack build "https://github.com/user/repo"
+agentstack client-side-build . --no-import
 
 # Build with custom dockerfile
-agentstack build . --dockerfile ./custom.Dockerfile
+agentstack client-side-build . --dockerfile ./custom.Dockerfile
 ```
-
-### server-side-build
-
-**EXPERIMENTAL:** Build an agent from a GitHub repository on the platform, instead of locally.
-
-This is useful if you don’t want to set up a local build environment or if you want to ensure the build happens in a consistent, controlled server environment.
-
-```bash
-agentstack server-side-build [OPTIONS] <github-url>
-```
-
-This command clones the GitHub repository, builds the agent image on the platform, and optionally adds the built agent to your workspace.
 
 **Options:**
-| Option                | Description                                                                                                |
-| --------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `--dockerfile <path>` | Use a custom Dockerfile path. Path should be relative to the repo root or a subdirectory.                  |
-| `--replace <id/name>` | Replace an existing agent. Accepts short agent ID, agent name, or part of the provider location.           |
-| `--add / --no-add`    | After the build completes, automatically add the agent to your Agent Stack instance. Default: `--no-add`. |
+
+| Option                 | Description                                                                               |
+|------------------------|-------------------------------------------------------------------------------------------|
+| `--dockerfile <path>`  | Use a custom Dockerfile path. Path should be relative to the repo root or a subdirectory. |
+| `--tag <name>`         | Docker tag for the agent                                                                  |
+| `--multi-platform`     | Build for multiple platforms                                                              |
+| `--push`               | Push the image to the target registry                                                     |
+| `--import/--no-import` | Import the image into Agent Stack (default: true)                                         |
 
 ## Model Commands
 
@@ -213,7 +250,7 @@ agentstack platform delete
 ```
 
 <Warning>
-This removes all agents, configurations, and data permanently.
+    This removes all agents, configurations, and data permanently.
 </Warning>
 
 ## MCP Commands

--- a/helm/templates/config/provider_templates.yaml
+++ b/helm/templates/config/provider_templates.yaml
@@ -108,6 +108,7 @@ data:
           {{- if .Values.providerBuilds.externalClusterExecutor.serviceAccountName }}
           serviceAccountName: {{ .Values.providerBuilds.externalClusterExecutor.serviceAccountName }}
           {{- end }}
+          terminationGracePeriodSeconds: 3
           imagePullSecrets:
             - name: {{.Values.providerBuilds.buildRegistry.secretName | quote}}
           securityContext:
@@ -127,6 +128,7 @@ data:
               args:
                 - -c
                 - |
+                  set -eo pipefail
                   echo "Cloning repository..."
                   # Check if GitHub token is available for this host
                   if [ -n "$GIT_TOKEN" ]; then
@@ -296,6 +298,7 @@ data:
                 - /bin/sh
                 - -c
                 - |
+                  set -eo pipefail
                   # Extract agent manifest
                   for i in $(seq 1 30); do
                     if nc -z 127.0.0.1 8000; then


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes -->
`build` now uses server-side build backend
previous build was renamed to `client-side-build`
`add` command uses server-side-build
`update` command uses server-side-build
```

╭─ Agent Management ─────────────────────────────────────────────────────────╮
│ add                               Install an agent (Docker, GitHub)        │
│ remove                            Uninstall an agent                       │
│ update                            Update an agent                          │
│ info                              Show agent details                       │
│ logs                              Stream agent execution logs              │
│ env                               Manage agent environment variables       │
│ build                             Build an agent remotely                  │
│ client-side-build                 Build an agent container image locally   │
╰────────────────────────────────────────────────────────────────────────────╯
```


## Linked Issues
<!-- Make sure the linked issue is always provided eg: -->
<!-- Closes #XYZ, Fixes #XYZ, Resolves #XYZ -->
Closes: #1623 
Closes: #1597
Closes: #1522 

## Documentation
- [ ] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.