### PR TITLE
fix(server): connector refresh for disconnected state

### DIFF
--- a/apps/agentstack-server/src/agentstack_server/service_layer/services/connector.py
+++ b/apps/agentstack-server/src/agentstack_server/service_layer/services/connector.py
@@ -139,9 +139,10 @@ class ConnectorService:
         async with self._uow() as uow:
             connector = await uow.connectors.get(connector_id=connector_id, user_id=user.id if user else None)
 
-        if connector.state not in (ConnectorState.connected, ConnectorState.auth_required):
+        if connector.state not in (ConnectorState.connected, ConnectorState.disconnected, ConnectorState.auth_required):
             raise PlatformError(
-                "Connector must be in connected or auth_required state", status_code=status.HTTP_400_BAD_REQUEST
+                "Connector must be in connected, disconnected or auth_required state",
+                status_code=status.HTTP_400_BAD_REQUEST,
             )
 
         await self._revoke_auth_token(connector=connector)


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes -->

Ensures that disconnected connector is probe-tested and can be reconnected automatically. Probe failure won't result in throwing out access token (manual disconnect still does).

## Linked Issues
<!-- Make sure the linked issue is always provided eg: -->
<!-- Closes #XYZ, Fixes #XYZ, Resolves #XYZ -->

supports #1606 

## Documentation
- [x] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.