### PR TITLE
fix(ui): css word breaking

### DIFF
--- a/apps/agentstack-ui/src/components/Toast/Toast.module.scss
+++ b/apps/agentstack-ui/src/components/Toast/Toast.module.scss
@@ -94,3 +94,7 @@
   grid-area: heading;
   font-weight: 600;
 }
+
+.message {
+  overflow-wrap: anywhere;
+}

--- a/apps/agentstack-ui/src/components/Toast/Toast.tsx
+++ b/apps/agentstack-ui/src/components/Toast/Toast.tsx
@@ -92,11 +92,11 @@ export function Toast({
 
           {message &&
             (renderMarkdown ? (
-              <LineClampText lines={4} useBlockElement>
+              <LineClampText className={classes.message} lines={4} useBlockElement>
                 <MarkdownContent>{message}</MarkdownContent>
               </LineClampText>
             ) : (
-              <div>{message}</div>
+              <div className={classes.message}>{message}</div>
             ))}
         </motion.div>
       )}

--- a/apps/agentstack-ui/src/modules/providers/variables/components/VariablesView.module.scss
+++ b/apps/agentstack-ui/src/modules/providers/variables/components/VariablesView.module.scss
@@ -5,7 +5,7 @@
 
 .name {
   inline-size: 30%;
-  word-break: break-all;
+  overflow-wrap: anywhere;
 }
 
 .value {


### PR DESCRIPTION
## Summary
Fixes a bug with incorrect word wrapping in Toast messages.

## Documentation
- [x] No Docs Needed: