### PR TITLE
fix(ui): dynamic server usage error

### DIFF
--- a/apps/agentstack-ui/src/app/(main)/(common)/page.tsx
+++ b/apps/agentstack-ui/src/app/(main)/(common)/page.tsx
@@ -5,6 +5,10 @@
 
 import { HomeView } from '#modules/home/components/HomeView.tsx';
 
+// The homepage fetches data via the server API client which reads request headers,
+// so force a dynamic render to avoid static generation errors.
+export const dynamic = 'force-dynamic';
+
 export default async function HomePage() {
   return <HomeView />;
 }


### PR DESCRIPTION
## Summary
The homepage fetches data via the server API client which reads request headers, so force a dynamic render to avoid static generation errors.

## Documentation
- [x] No Docs Needed: