### PR TITLE
fix(ui): hide mermaid diagram during streaming

### DIFF
--- a/apps/agentstack-ui/src/components/MarkdownContent/MarkdownContent.tsx
+++ b/apps/agentstack-ui/src/components/MarkdownContent/MarkdownContent.tsx
@@ -13,6 +13,7 @@ import type { PluggableList } from 'unified';
 
 import { components, type ExtendedComponents } from './components';
 import { Code } from './components/Code';
+import { MermaidDiagram } from './components/MermaidDiagram';
 import classes from './MarkdownContent.module.scss';
 import { rehypePlugins } from './rehype';
 import { remarkPlugins } from './remark';
@@ -20,6 +21,7 @@ import { urlTransform } from './utils';
 
 export interface MarkdownContentProps {
   codeBlocksExpanded?: boolean;
+  showMermaidDiagrams?: boolean;
   children?: string;
   className?: string;
   remarkPlugins?: PluggableList;
@@ -28,6 +30,7 @@ export interface MarkdownContentProps {
 
 export function MarkdownContent({
   codeBlocksExpanded,
+  showMermaidDiagrams,
   className,
   remarkPlugins: remarkPluginsProps,
   components: componentsProps,
@@ -37,9 +40,10 @@ export function MarkdownContent({
     () => ({
       ...components,
       code: ({ ...props }) => <Code {...props} forceExpand={codeBlocksExpanded} />,
+      mermaidDiagram: ({ ...props }) => <MermaidDiagram {...props} showDiagram={showMermaidDiagrams} />,
       ...componentsProps,
     }),
-    [codeBlocksExpanded, componentsProps],
+    [codeBlocksExpanded, showMermaidDiagrams, componentsProps],
   );
 
   const extendedRemarkPlugins = useMemo(() => [...remarkPlugins, ...(remarkPluginsProps ?? [])], [remarkPluginsProps]);

--- a/apps/agentstack-ui/src/modules/messages/components/MessageContent.tsx
+++ b/apps/agentstack-ui/src/modules/messages/components/MessageContent.tsx
@@ -42,7 +42,12 @@ export const MessageContent = memo(function MessageContent({ message }: Props) {
     }
 
     return (
-      <ChatMarkdownContent className={classes.root} sources={sources} codeBlocksExpanded={isPending}>
+      <ChatMarkdownContent
+        className={classes.root}
+        sources={sources}
+        codeBlocksExpanded={isPending}
+        showMermaidDiagrams={!isPending}
+      >
         {content}
       </ChatMarkdownContent>
     );

--- a/apps/agentstack-ui/src/modules/runs/components/RunOutputBox.tsx
+++ b/apps/agentstack-ui/src/modules/runs/components/RunOutputBox.tsx
@@ -31,7 +31,7 @@ export function RunOutputBox({ isPending, text, downloadFileName, sources, child
       )}
 
       {text && (
-        <ChatMarkdownContent sources={sources} codeBlocksExpanded={isPending}>
+        <ChatMarkdownContent sources={sources} codeBlocksExpanded={isPending} showMermaidDiagrams={!isPending}>
           {text}
         </ChatMarkdownContent>
       )}


### PR DESCRIPTION
## Summary
This PR hides the Mermaid diagram while a message is streaming to prevent flickering. I also noticed that when loading a conversation from history, the diagram briefly flickers on the initial render as well. Unfortunately, I haven’t been able to eliminate that part yet - Mermaid doesn’t integrate very smoothly with React. I’ll continue exploring potential fixes.

## Documentation
- [x] No Docs Needed: