### PR TITLE
fix(sdk): use typing_extension for TypeAliasType due to python3.11 compatibility

### DIFF
--- a/apps/agentstack-sdk-py/src/agentstack_sdk/a2a/extensions/services/form.py
+++ b/apps/agentstack-sdk-py/src/agentstack_sdk/a2a/extensions/services/form.py
@@ -4,9 +4,10 @@
 
 from __future__ import annotations
 
-from typing import Self, TypedDict, TypeVar, cast
+from typing import Self, TypeVar, cast
 
 from pydantic import BaseModel, TypeAdapter
+from typing_extensions import TypedDict
 
 from agentstack_sdk.a2a.extensions.base import BaseExtensionClient, BaseExtensionServer, BaseExtensionSpec
 from agentstack_sdk.a2a.extensions.common.form import FormRender, FormResponse

--- a/apps/agentstack-sdk-py/src/agentstack_sdk/a2a/types.py
+++ b/apps/agentstack-sdk-py/src/agentstack_sdk/a2a/types.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import typing
 import uuid
-from typing import Generic, Literal, TypeAlias, TypeAliasType, Union
+from typing import Generic, Literal, TypeAlias, Union
 
 from a2a.types import (
     Artifact,
@@ -20,6 +20,7 @@ from a2a.types import (
     TextPart,
 )
 from pydantic import Field, model_validator
+from typing_extensions import TypeAliasType
 
 K = typing.TypeVar("K")
 V = typing.TypeVar("V")


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes -->

## Linked Issues
<!-- Make sure the linked issue is always provided eg: -->
<!-- Closes #XYZ, Fixes #XYZ, Resolves #XYZ -->


## Documentation
- [x] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.