### PR TITLE
fix: simplifying bump for release branch

### DIFF
--- a/tasks.toml
+++ b/tasks.toml
@@ -397,12 +397,6 @@ if gum confirm "Publish version $publish_version now?"; then
   (
     set -eux -o pipefail
     {{ mise_bin }} release:_bump --version="$publish_version"
-
-    git add .
-    git commit -m "deploy: v$publish_version"
-    git tag "v$publish_version"
-    git push origin tag "v$publish_version"
-    git push origin release
   )
   
   # Backport install.sh version updates to main branch


### PR DESCRIPTION
## Summary
Decoupling bumping from release bumping of RC. This would allow user to simply call bump on release without specifying next RC number.

## Linked Issues
Part of #1666 


## Documentation
- [X] No Docs Needed:

This has already been documented in Contributing.MD