### PR TITLE
fix(server,sdk): a2a security schemes in agent card

### DIFF
--- a/apps/agentstack-sdk-py/src/agentstack_sdk/server/app.py
+++ b/apps/agentstack-sdk-py/src/agentstack_sdk/server/app.py
@@ -18,8 +18,6 @@ from a2a.server.tasks import (
 from a2a.types import AgentInterface, TransportProtocol
 from fastapi import APIRouter, Depends, FastAPI
 from fastapi.applications import AppType
-from starlette.authentication import AuthenticationBackend
-from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.types import Lifespan
 
 from agentstack_sdk.server.agent import Agent, Executor
@@ -39,7 +37,6 @@ def create_app(
     dependencies: list[Depends] | None = None,  # pyright: ignore [reportGeneralTypeIssues]
     override_interfaces: bool = True,
     task_timeout: timedelta = timedelta(minutes=10),
-    auth_backend: AuthenticationBackend | None = None,
     **kwargs,
 ) -> FastAPI:
     queue_manager = queue_manager or InMemoryQueueManager()
@@ -77,10 +74,6 @@ def create_app(
         dependencies=dependencies,
         **kwargs,
     )
-
-    if auth_backend:
-        rest_app.add_middleware(AuthenticationMiddleware, backend=auth_backend)
-        jsonrpc_app.add_middleware(AuthenticationMiddleware, backend=auth_backend)
 
     rest_app.mount("/jsonrpc", jsonrpc_app)
     rest_app.include_router(APIRouter(lifespan=lifespan))

--- a/apps/agentstack-sdk-py/src/agentstack_sdk/types.py
+++ b/apps/agentstack-sdk-py/src/agentstack_sdk/types.py
@@ -1,7 +1,11 @@
 # Copyright 2025 © BeeAI a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
+import abc
 from typing import TYPE_CHECKING, TypeAlias
+
+from a2a.types import AgentCard
+from starlette.authentication import AuthenticationBackend
 
 if TYPE_CHECKING:
     JsonValue: TypeAlias = list["JsonValue"] | dict[str, "JsonValue"] | str | bool | int | float | None
@@ -13,3 +17,8 @@ else:
 
     JsonValue = TypeAliasType("JsonValue", "Union[dict[str, JsonValue], list[JsonValue], str, int, float, bool, None]")  # noqa: UP007
     JsonDict = TypeAliasType("JsonDict", "dict[str, JsonValue]")
+
+
+class SdkAuthenticationBackend(AuthenticationBackend, abc.ABC):
+    @abc.abstractmethod
+    def update_card_security_schemes(self, agent_card: AgentCard) -> None: ...


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes -->
Add platform proxy auth schemes to agent card schemes:

```
        "security": [
          {
            "platform_context_token": []
          },
          {
            "platform_context_token": [],
            "basic": []
          }
        ],
        "securitySchemes": {
          "platform_context_token": {
            "bearerFormat": "JWT",
            "description": "Platform context token, issued by the AgentStack server using POST /api/v1/context/{context_id}/token.",
            "scheme": "bearer",
            "type": "http"
          },
          "basic": {
            "bearerFormat": null,
            "description": null,
            "scheme": "basic",
            "type": "http"
          }
        },
```


## Linked Issues
<!-- Make sure the linked issue is always provided eg: -->
<!-- Closes #XYZ, Fixes #XYZ, Resolves #XYZ -->


## Documentation
- [x] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.