### PR TITLE
feat(ui): make Fulfillments partial

### DIFF
--- a/apps/agentstack-sdk-ts/src/client/core/extensions/types.ts
+++ b/apps/agentstack-sdk-ts/src/client/core/extensions/types.ts
@@ -30,7 +30,7 @@ export interface A2AServiceExtension<U extends string, D, F> extends A2AExtensio
   getFulfillmentsSchema: () => z.ZodSchema<F>;
 }
 
-export interface Fulfillments {
+export type Fulfillments = Partial<{
   llm: (demand: LLMDemands) => Promise<LLMFulfillments>;
   embedding: (demand: EmbeddingDemands) => Promise<EmbeddingFulfillments>;
   mcp: (demand: MCPDemands) => Promise<MCPFulfillments>;
@@ -43,7 +43,7 @@ export interface Fulfillments {
    * @deprecated - keeping this for backwards compatibility, context token is now passed via A2A client headers
    */
   getContextToken: () => ContextToken;
-}
+}>;
 
 export type UserMetadataInputs = Partial<{
   form: FormValues;

--- a/apps/agentstack-sdk-ts/src/client/core/handle-agent-card.ts
+++ b/apps/agentstack-sdk-ts/src/client/core/handle-agent-card.ts
@@ -46,37 +46,40 @@ export const handleAgentCard = (agentCard: { capabilities: AgentCapabilities }) 
   const resolveMetadata = async (fulfillments: Fulfillments) => {
     let fulfilledMetadata: Record<string, unknown> = {};
 
-    fulfilledMetadata = platformApiExtension(fulfilledMetadata, fulfillments.getContextToken());
+    if (fulfillments.getContextToken) {
+      fulfilledMetadata = platformApiExtension(fulfilledMetadata, fulfillments.getContextToken());
+    }
 
-    if (llmDemands) {
+    if (llmDemands && fulfillments.llm) {
       fulfilledMetadata = fulfillLlmDemand(fulfilledMetadata, await fulfillments.llm(llmDemands));
     }
 
-    if (embeddingDemands) {
+    if (embeddingDemands && fulfillments.embedding) {
       fulfilledMetadata = fulfillEmbeddingDemand(fulfilledMetadata, await fulfillments.embedding(embeddingDemands));
     }
 
-    if (mcpDemands) {
+    if (mcpDemands && fulfillments.mcp) {
       fulfilledMetadata = fulfillMcpDemand(fulfilledMetadata, await fulfillments.mcp(mcpDemands));
     }
 
-    if (oauthDemands) {
+    if (oauthDemands && fulfillments.oauth) {
       fulfilledMetadata = fulfillOAuthDemand(fulfilledMetadata, await fulfillments.oauth(oauthDemands));
     }
 
-    if (settingsDemands) {
+    if (settingsDemands && fulfillments.settings) {
       fulfilledMetadata = fulfillSettingsDemand(fulfilledMetadata, await fulfillments.settings(settingsDemands));
     }
 
-    if (secretDemands) {
+    if (secretDemands && fulfillments.secrets) {
       fulfilledMetadata = fulfillSecretDemand(fulfilledMetadata, await fulfillments.secrets(secretDemands));
     }
 
-    if (formDemands) {
+    if (formDemands && fulfillments.form) {
       fulfilledMetadata = fulfillFormDemand(fulfilledMetadata, await fulfillments.form(formDemands));
     }
 
-    const oauthRedirectUri = fulfillments.oauthRedirectUri();
+    const oauthRedirectUri = fulfillments.oauthRedirectUri?.();
+
     if (oauthRedirectUri) {
       fulfilledMetadata = {
         ...fulfilledMetadata,


### PR DESCRIPTION
## Summary
Updates the `Fulfillments` interface to be entirely partial and adds safe handling in `handle-agent-card.ts`.

I don't like that all extensions need to be enumerated and handled manually, so I plan to modify it a bit in the future to some kind of configuration object, but that's outside the scope of this PR.

## Linked Issues
Refs: https://github.com/i-am-bee/agentstack/issues/1818


## Documentation
- [x] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.