### PR TITLE
feat(ui): add markdown syntax highlighting

### DIFF
--- a/apps/agentstack-ui/src/components/SyntaxHighlighter/languages.ts
+++ b/apps/agentstack-ui/src/components/SyntaxHighlighter/languages.ts
@@ -14,6 +14,7 @@ export async function registerLanguagesAsync(highlighter: typeof Highlighter) {
     { default: javascript },
     { default: typescript },
     { default: python },
+    { default: markdown },
   ] = await Promise.all([
     import('react-syntax-highlighter/dist/esm/languages/hljs/bash'),
     import('react-syntax-highlighter/dist/esm/languages/hljs/shell'),
@@ -22,6 +23,7 @@ export async function registerLanguagesAsync(highlighter: typeof Highlighter) {
     import('react-syntax-highlighter/dist/esm/languages/hljs/javascript'),
     import('react-syntax-highlighter/dist/esm/languages/hljs/typescript'),
     import('react-syntax-highlighter/dist/esm/languages/hljs/python'),
+    import('react-syntax-highlighter/dist/esm/languages/hljs/markdown'),
   ]);
 
   highlighter.registerLanguage('bash', bash);
@@ -31,4 +33,5 @@ export async function registerLanguagesAsync(highlighter: typeof Highlighter) {
   highlighter.registerLanguage('javascript', javascript);
   highlighter.registerLanguage('typescript', typescript);
   highlighter.registerLanguage('python', python);
+  highlighter.registerLanguage('markdown', markdown);
 }


### PR DESCRIPTION
## Summary
Added markdown syntax highlighting support to code blocks in the UI by registering the markdown language with the syntax highlighter component.

## Linked Issues
Closes #1100


## Documentation
- [x] No Docs Needed: fix
