### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/development/agent-integration/agent-settings.mdx
+++ b/docs/development/agent-integration/agent-settings.mdx
@@ -8,7 +8,7 @@ Sometimes you need to give users control over how your agent behaves during a co
 The Agent Stack platform provides a Settings extension that creates an interactive UI component where users can configure these options before or during their interaction with your agent.
 
 <Tip>
-Settings extensions are a type of [Service Extension](/development/agent-integration/overview#dependency-injection-service-extensions) that allows you to easily "inject dependencies" into your agent. This follows the inversion of control principle where your agent defines what it needs, and the platform provides those dependencies.
+Settings extensions are a type of [Service Extension](../agent-integration/overview#dependency-injection-service-extensions) that allows you to easily "inject dependencies" into your agent. This follows the inversion of control principle where your agent defines what it needs, and the platform provides those dependencies.
 </Tip>
 
 ## Quickstart

--- a/docs/development/agent-integration/env-variables.mdx
+++ b/docs/development/agent-integration/env-variables.mdx
@@ -27,7 +27,7 @@ Add an `EnvVar` list to the `variables` field in your `AgentDetail` configuratio
 </Step>
 
 <Step title="Deploy your agent to the Agent Stack">
-Use `agentstack add` command to [deploy your agent in Agent Stack](/development/deploy-agents/deploy-your-agents)
+Use `agentstack add` command to [deploy your agent in Agent Stack](../deploy-agents/deploy-your-agents)
 </Step>
 
 <Step title="Configure the variables via CLI">

--- a/docs/development/agent-integration/overview.mdx
+++ b/docs/development/agent-integration/overview.mdx
@@ -7,7 +7,7 @@ The Server SDK is a Python library that enhances your existing AI agents with pl
 
 Built on top of the [Agent2Agent Protocol (A2A)](https://a2a-protocol.org/), the SDK wraps your agent implementation and adds powerful functionality through [A2A extensions](https://a2a-protocol.org/latest/topics/extensions/).
 
-This enables your agent to leverage platform services like [LLM providers](/development/agent-integration/llm-proxy-service), [file storage](/development/agent-integration/files), [vector databases](/development/agent-integration/rag), and rich UI components. That's all without rewriting your core agent logic.
+This enables your agent to leverage platform services like [LLM providers](./llm-proxy-service), [file storage](./files), [vector databases](./rag), and rich UI components. That's all without rewriting your core agent logic.
 
 ## What the SDK Provides
 

--- a/docs/development/agent-integration/rag.mdx
+++ b/docs/development/agent-integration/rag.mdx
@@ -38,7 +38,7 @@ from agentstack_sdk.a2a.extensions import (
 )
 from agentstack_sdk.server.context import RunContext
 
-# Fileformats supported by the text-extraction service (docling)
+# File formats supported by the text-extraction service (docling)
 default_input_modes = [
     "text/plain",
     "application/pdf",
@@ -74,7 +74,7 @@ async def rag_agent(
 ```
 
 Agent Stack uses [docling](https://docling-project.github.io/docling/) for extracting text out of documents in various
-[supoported formats](https://docling-project.github.io/docling/usage/supported_formats/). To select which formats the
+[supported formats](https://docling-project.github.io/docling/usage/supported_formats/). To select which formats the
 agent can accept, use the `default_input_modes` parameter in the agent decorator.
 
 First, let's build a set of functions to process the documents which we will then use in the agent.
@@ -368,6 +368,6 @@ async def rag_agent(
 To further improve the agent, learn how to use other parts of the platform such as LLMs,
 file uploads and conversations:
 
-- [LLM extension](/development/agent-integration/llm-proxy-service)
-- [Multi-turn conversations](/development/agent-integration/multi-turn)
-- [File handling](/development/agent-integration/files)
+- [LLM extension](./llm-proxy-service)
+- [Multi-turn conversations](./multi-turn)
+- [File handling](./files)

--- a/docs/development/custom-ui/client-sdk/api-client.mdx
+++ b/docs/development/custom-ui/client-sdk/api-client.mdx
@@ -77,7 +77,7 @@ interface CreateContextResponse {
 
 ### `createContextToken(params: CreateContextTokenParams)`
 
-Generates a context token with specific permissions. Context tokens are used to grant agents access to platform resources through the [Platform API extension](/development/custom-ui/client-sdk/extensions#dependency-injection-service-extensions).
+Generates a context token with specific permissions. Context tokens are used to grant agents access to platform resources through the [Platform API extension](./extensions#dependency-injection-service-extensions).
 
 **Parameters:**
 
@@ -290,4 +290,4 @@ All API methods are fully typed with TypeScript and use Zod schemas for runtime 
 
 ## Next Steps
 
-- **[Extensions](/development/custom-ui/client-sdk/extensions)** - Learn how to use the API client with extension fulfillments
+- **[Extensions](./extensions)** - Learn how to use the API client with extension fulfillments

--- a/docs/development/custom-ui/client-sdk/overview.mdx
+++ b/docs/development/custom-ui/client-sdk/overview.mdx
@@ -92,5 +92,5 @@ The API client is typically used alongside extension fulfillments. For example, 
 ## Next Steps
 
 Now that you understand the basic concepts:
-- **[Extensions](/development/custom-ui/client-sdk/extensions)** - Deep dive into service and UI extensions
-- **[API Client](/development/custom-ui/client-sdk/api-client)** - Complete reference for the AgentStack platform API client
+- **[Extensions](./extensions)** - Deep dive into service and UI extensions
+- **[API Client](./api-client)** - Complete reference for the AgentStack platform API client

--- a/docs/development/deploy-agent-stack/authenticate-cli-to-server.mdx
+++ b/docs/development/deploy-agent-stack/authenticate-cli-to-server.mdx
@@ -7,7 +7,7 @@ Use the Agent Stack CLI to configure and manage remote Agent Stack deployments. 
 
 ## Prerequisites
 
-- Agent Stack CLI installed locally ([Quickstart](/development/introduction/quickstart))
+- Agent Stack CLI installed locally ([Quickstart](../introduction/quickstart))
 - URL of your deployed Agent Stack server
 - Authentication credentials for the server
 

--- a/docs/development/deploy-agents/building-agents.mdx
+++ b/docs/development/deploy-agents/building-agents.mdx
@@ -7,7 +7,7 @@ To help you get started quickly, we’ve created a ready-to-use starter reposito
 
 ## Prerequisites
 
-- Agent Stack installed ([Quickstart](/development/introduction/quickstart))
+- Agent Stack installed ([Quickstart](../introduction/quickstart))
 - [uv](https://docs.astral.sh/uv/) package manager (should be already installed if you followed the quickstart)
 
 ## Start From Template
@@ -142,19 +142,19 @@ The starter repo mainly provides basic scaffolding, a GitHub workflow, and a Doc
 After building your agent, you can enhance it and learn more:
 
 <CardGroup cols={2}>
-<Card title="Agent Details" icon="id-card" href="/development/agent-integration/agent-details">
+<Card title="Agent Details" icon="id-card" href="../agent-integration/agent-details">
 Customize your agent's name, description, and how it appears in the UI
 </Card>
 
-<Card title="Working with Messages" icon="comment" href="/development/agent-integration/messages">
+<Card title="Working with Messages" icon="comment" href="../agent-integration/messages">
 Learn how agents and clients communicate through structured messaging
 </Card>
 
-<Card title="Multi-Turn Conversations" icon="comments" href="/development/agent-integration/multi-turn">
+<Card title="Multi-Turn Conversations" icon="comments" href="../agent-integration/multi-turn">
 Understand how to handle multi-turn conversations and maintain context
 </Card>
 
-<Card title="Working with Files" icon="file" href="/development/agent-integration/files">
+<Card title="Working with Files" icon="file" href="../agent-integration/files">
 Work with files to provide inputs or store outputs for your agent
 </Card>
 </CardGroup>

--- a/docs/development/deploy-agents/deploy-your-agents.mdx
+++ b/docs/development/deploy-agents/deploy-your-agents.mdx
@@ -8,8 +8,8 @@ Once you've wrapped your agent with the Agent Stack server, you need to containe
 ## Prerequisites
 
 - Docker installed and running (or use GitHub Actions via template)
-- Agent wrapped with Agent Stack SDK ([Wrap Existing Agents](/development/deploy-agents/wrap-existing-agents) or [Build New Agent](/development/deploy-agents/building-agents))
-- Agent Stack installed ([Quickstart](/development/introduction/quickstart))
+- Agent wrapped with Agent Stack SDK ([Wrap Existing Agents](./wrap-existing-agents) or [Build New Agent](./building-agents))
+- Agent Stack installed ([Quickstart](../introduction/quickstart))
 
 ## Containerize Your Agent
 
@@ -175,19 +175,19 @@ agentstack build . --dockerfile=./deploy/Containerfile --import
 Now that your agent is deployed, enhance it with extensions:
 
 <CardGroup cols={2}>
-<Card title="LLM Service" icon="rotate" href="/development/agent-integration/llm-proxy-service">
+<Card title="LLM Service" icon="rotate" href="../agent-integration/llm-proxy-service">
 Change your agent's LLM at runtime and manage model connections dynamically
 </Card>
 
-<Card title="Agent Trajectory Visualization" icon="list" href="/development/agent-integration/trajectory">
+<Card title="Agent Trajectory Visualization" icon="list" href="../agent-integration/trajectory">
 Visualize your agent’s decision-making and interactions over time in the UI
 </Card>
 
-<Card title="Citations & Source Linking" icon="link" href="/development/agent-integration/citations">
+<Card title="Citations & Source Linking" icon="link" href="../agent-integration/citations">
 Display references and link sources for transparency, directly in the UI
 </Card>
 
-<Card title="Structured Inputs (Forms)" icon="square-poll-horizontal" href="/development/agent-integration/forms">
+<Card title="Structured Inputs (Forms)" icon="square-poll-horizontal" href="../agent-integration/forms">
 Guide your users to provide consistent information with the form extension
 </Card>
 </CardGroup>

--- a/docs/development/deploy-agents/wrap-existing-agents.mdx
+++ b/docs/development/deploy-agents/wrap-existing-agents.mdx
@@ -9,7 +9,7 @@ This gives you instant access to the Agent Stack UI, observability features, and
 
 ## Prerequisites
 
-- Agent Stack installed ([Quickstart](/development/introduction/quickstart))
+- Agent Stack installed ([Quickstart](../introduction/quickstart))
 - An existing agent implementation
 - Python 3.12+ environment
 

--- a/docs/development/experimental/a2a-proxy.mdx
+++ b/docs/development/experimental/a2a-proxy.mdx
@@ -32,7 +32,7 @@ That's it! Your agent is now registered with Agent Stack and accessible through 
 The proxy creates a bridge between your A2A agent and Agent Stack by:
 
 1. **Intercepting agent card requests** - Captures `/.well-known/agent-card.json` requests from any A2A client
-2. **Adding Agent Details extension** - Automatically injects the necessary [AgentDetail](/development/agent-integration/agent-details) extension data that enables the agent to work within the Agent Stack ecosystem
+2. **Adding Agent Details extension** - Automatically injects the necessary [AgentDetail](../agent-integration/agent-details) extension data that enables the agent to work within the Agent Stack ecosystem
 3. **Auto-registration** - Automatically registers the modified agent with the Agent Stack, making it immediately available
 
 <Note>

--- a/docs/development/introduction/welcome.mdx
+++ b/docs/development/introduction/welcome.mdx
@@ -38,16 +38,16 @@ Your agents request infrastructure services at runtime through A2A protocol exte
 ## Get Started
 
 <CardGroup cols={2}>
-  <Card title="Quickstart" icon="rocket" href="/development/introduction/quickstart">
+  <Card title="Quickstart" icon="rocket" href="./quickstart">
     Get up and running in one command
   </Card>
-  <Card title="Wrap Existing Agents" icon="box" href="/development/deploy-agents/wrap-existing-agents">
+  <Card title="Wrap Existing Agents" icon="box" href="../deploy-agents/wrap-existing-agents">
     Deploy your existing agents to Agent Stack
   </Card>
-  <Card title="Build New Agents" icon="code" href="/development/deploy-agents/building-agents">
+  <Card title="Build New Agents" icon="code" href="../deploy-agents/building-agents">
     Build your first agent with the SDK
   </Card>
-  <Card title="Deploy to Production" icon="server" href="/development/deploy-agent-stack/deployment-guide">
+  <Card title="Deploy to Production" icon="server" href="../deploy-agent-stack/deployment-guide">
     Deploy Agent Stack to Kubernetes for your team
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

* many links were broken due to stable and development roots
* addition links broken due to rearranging
* examples links just don't exist

* Use relative links to help maintain stable and development
* Misc fixes to links and typos
* Remove the links to missing examples for now

## Linked Issues

Fixes #1856 
Fixes #1884 



## Documentation
- [x] No Docs Needed:

This is doc fixing.