### PR TITLE
docs: add external link validation manual tasks

### DIFF
--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -1,0 +1,42 @@
+# Lychee configuration for link checking
+# See: https://lychee.cli.rs/#/usage/config
+
+# Base URL or website root directory to check relative URLs.
+# We skip these (use mintlify), but need this to pass URL parsing.
+base_url = "https://localhost"
+
+# Uncomment to use verbose info to see redirects
+# verbose = "info"
+
+# Exclude patterns
+exclude = [
+  # Local development URLs
+  '^https?://localhost',
+  '^https?://127\.0\.0\.1',
+  # If we don't skip npmjs then we need to accept 403
+  '^https://www\.npmjs\.com',
+  # Example domains
+  '^https://your-public-url\.',
+  '^https://api\.agentstack\.example\.com',
+  '^https://api\.myapp\.com',
+  '^https://keycloak\.myapp\.com',
+]
+
+# GitHub API token to avoid github warning
+github_token = "secret"
+
+# Exclude paths
+exclude_path = ["node_modules"]
+
+# Accept status codes
+accept = [200, 206, 302, 307]
+
+# Timeout for requests
+timeout = 20
+
+# Retry settings
+max_retries = 5
+retry_wait_time = 2
+
+# Ignore code block examples
+include_verbatim = false

--- a/docs/tasks.toml
+++ b/docs/tasks.toml
@@ -59,3 +59,11 @@ dir = "{{config_root}}/docs"
 run = "pnpm mintlify broken-links"
 sources = ["**/*.mdx"]
 outputs = { auto = true }
+
+## manual check
+
+["docs:manual-check:external-links"]
+dir = "{{config_root}}/docs"
+sources = ["**/*.md", "**/*.mdx", "!node_modules/**", "lychee.toml"]
+outputs = { auto=true }
+run = "lychee --config lychee.toml '**/*.md' '**/*.mdx'"

--- a/mise.lock
+++ b/mise.lock
@@ -33,6 +33,13 @@ backend = "core:java"
 version = "0.7.0"
 backend = "aqua:yannh/kubeconform"
 
+[[tools.lychee]]
+version = "0.22.0"
+backend = "aqua:lycheeverse/lychee"
+
+[[tools.lychee.checksums]]
+"lychee-arm64-macos.dmg" = "sha256:197bf8b7aafd190e38ec8e931a16e38a2d1d2b1e9fa13aa4874d004ba09c4d05"
+
 [[tools.maven]]
 version = "3.9.12"
 backend = "aqua:apache/maven"

--- a/mise.toml
+++ b/mise.toml
@@ -24,6 +24,7 @@ yq = "latest"
 fd = "latest"
 "github:google/addlicense" = "latest"
 gum = "latest"
+lychee = "latest"
 
 [settings]
 experimental = true # for python.uv_venv_auto


### PR DESCRIPTION
## Summary

docs: add convenience tool for checking external links
Manual tool only for now. There are some flakey redirects and auth things that we probably
do not want in CI. We can just use this to do some doc cleanup for now.

## Linked Issues
Fixes #1926 

## Documentation
- [x] No Docs Needed:
