### PR TITLE
docs: fix an external link that moved

### DIFF
--- a/docs/development/community/acp-a2a-migration-guide.mdx
+++ b/docs/development/community/acp-a2a-migration-guide.mdx
@@ -310,4 +310,4 @@ yield response_text
 ## Complete Examples
 
 1. https://github.com/i-am-bee/agentstack/blob/main/agents/chat/src/chat/agent.py
-2. https://github.com/jenna-winkler/granite_chat/blob/main/src/beeai_agents/agent.py
+2. https://github.com/jenna-winkler/agentstack-showcase/blob/main/src/agentstack_agents/agent.py


### PR DESCRIPTION
## Summary
The link to example agent.py path changed (and repo renamed).

## Linked Issues
Closes #1894 



## Documentation
- [x] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.