### PR TITLE
docs: Windows install command fix

### DIFF
--- a/docs/development/introduction/quickstart.mdx
+++ b/docs/development/introduction/quickstart.mdx
@@ -152,7 +152,7 @@ This will make local agents accessible over the local network, which is needed f
 <Step title="Install Agent Stack">
 
 ```bash
-uv python install --quiet --python-preference=only-managed --no-bin 3.13; uv tool install --refresh --force --python-preference=only-managed --python=3.13 agentstack-cli; agentstack self install
+uv python install --quiet --python-preference=only-managed --no-bin 3.13 && uv tool install --refresh --force --python-preference=only-managed --python=3.13 agentstack-cli && agentstack self install
 ```
 
 Follow the interactive prompts to finish the installation and setup.


### PR DESCRIPTION
## Summary
Don't use semi-colon separated commands.  Use &&.

## Linked Issues
Fixes #1927 

## Documentation
- [ ] No Docs Needed:
