### PR TITLE
docs: mention to run in powershell where needed in quickstart for Windows

### DIFF
--- a/docs/development/introduction/quickstart.mdx
+++ b/docs/development/introduction/quickstart.mdx
@@ -157,7 +157,7 @@ Run in PowerShell:
 uv python install --quiet --python-preference=only-managed --no-bin 3.13; uv tool install --refresh --force --python-preference=only-managed --python=3.13 agentstack-cli; agentstack self install
 ```
 
-Follow the instructions to finish the installation and setup.
+Follow the interactive prompts to finish the installation and setup.
 
 </Step>
 </Steps>


### PR DESCRIPTION
## Summary

Add missing mention of "Run in PowerShell" because the command with semi-colons fails on command-line.

Also tweaked the mention of interactive prompts because there are none. Saying "follow instructions" work for the printed HINTs about setup and would also work if it became interactive.

## Linked Issues
Fixes #1927 

## Documentation
- [ ] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.