### PR TITLE
docs: moving and revising observability page

### DIFF
--- a/docs/development/agent-integration/observability.mdx
+++ b/docs/development/agent-integration/observability.mdx
@@ -57,7 +57,7 @@ For telemetry to flow successfully, it must be enabled at three levels:
 </Steps>
 
 ## Agent SDK Configuration
-Before configuring an observaility platform, your agent code must be "telemetry-aware." This configuration applies to all implementations, whether you are using local Phoenix or a cloud provider like Langfuse.
+Before configuring an observability platform, your agent code must be "telemetry-aware." This configuration applies to all implementations, whether you are using local Phoenix or a cloud provider like Langfuse.
 
 You must initialize instrumentation at the agent logic level and enable the export flag in the Agent Stack SDK:
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -139,7 +139,8 @@
               "development/agent-integration/env-variables",
               "development/agent-integration/error",
               "development/agent-integration/tool-calls",
-              "development/agent-integration/canvas"
+              "development/agent-integration/canvas",
+              "development/agent-integration/observability"
             ]
           },
           {
@@ -152,9 +153,8 @@
             "group": "Deploy Agent Stack",
             "pages": [
               "development/deploy-agent-stack/deployment-guide",
-              "development/deploy-agent-stack/authenticate-cli-to-server",
-              "development/deploy-agent-stack/observability"
-            ]
+              "development/deploy-agent-stack/authenticate-cli-to-server"
+                      ]
           },
           {
             "group": "Custom UI Integration",

--- a/docs/stable/agent-integration/observability.mdx
+++ b/docs/stable/agent-integration/observability.mdx
@@ -57,7 +57,7 @@ For telemetry to flow successfully, it must be enabled at three levels:
 </Steps>
 
 ## Agent SDK Configuration
-Before configuring an observaility platform, your agent code must be "telemetry-aware." This configuration applies to all implementations, whether you are using local Phoenix or a cloud provider like Langfuse.
+Before configuring an observability platform, your agent code must be "telemetry-aware." This configuration applies to all implementations, whether you are using local Phoenix or a cloud provider like Langfuse.
 
 You must initialize instrumentation at the agent logic level and enable the export flag in the Agent Stack SDK:
 


### PR DESCRIPTION
## Summary
Revising the observability docs for usability and clarity. Also moved it out of the "Deploy Agent Stack" section and into "Agent integration" section.

Note: this PR edits stable docs so it will fail the docs check

## Linked Issues
#1967 


## Documentation
These are docs

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.