### PR TITLE
fix(ui): use callback url on auth error page

### DIFF
--- a/apps/agentstack-ui/src/modules/auth/components/AuthErrorPage.tsx
+++ b/apps/agentstack-ui/src/modules/auth/components/AuthErrorPage.tsx
@@ -13,10 +13,10 @@ import { routes } from '#utils/router.ts';
 import classes from './AuthErrorPage.module.scss';
 
 interface Props {
-  redirectTo?: string;
+  callbackUrl?: string;
 }
 
-export function AuthErrorPage({ redirectTo = routes.signIn() }: Props) {
+export function AuthErrorPage({ callbackUrl = routes.signIn() }: Props) {
   return (
     <div className={classes.root}>
       <InlineNotification
@@ -26,7 +26,7 @@ export function AuthErrorPage({ redirectTo = routes.signIn() }: Props) {
         hideCloseButton
         lowContrast
       />
-      <Button kind="primary" onClick={() => signOut({ redirectTo })}>
+      <Button kind="primary" onClick={() => signOut({ redirectTo: callbackUrl })}>
         Sign in again
       </Button>
     </div>

--- a/apps/agentstack-ui/src/modules/auth/components/SignInProviders.tsx
+++ b/apps/agentstack-ui/src/modules/auth/components/SignInProviders.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 const authProvider = getProvider();
 
-export async function SignInProviders({ callbackUrl: redirectTo = routes.home() }: Props) {
+export async function SignInProviders({ callbackUrl = routes.home() }: Props) {
   if (!authProvider) {
     return null;
   }
@@ -27,10 +27,10 @@ export async function SignInProviders({ callbackUrl: redirectTo = routes.home() 
   const hasExistingToken = session?.user != null;
 
   if (hasExistingToken) {
-    return <AuthErrorPage redirectTo={redirectTo} />;
+    return <AuthErrorPage callbackUrl={callbackUrl} />;
   }
 
-  return <AutoSignIn signIn={handleSignIn.bind(null, { providerId: authProvider.id, redirectTo })} />;
+  return <AutoSignIn signIn={handleSignIn.bind(null, { providerId: authProvider.id, redirectTo: callbackUrl })} />;
 }
 
 async function handleSignIn({ providerId, redirectTo }: { providerId: string; redirectTo: string }) {


### PR DESCRIPTION
## Summary
After a server auth error (401), the UI shows an error page if a valid token is present to prevent a redirect loop. The user can try logging in again via the provided button, but the callback URL wasn’t being passed along for use after a successful login. This PR fixes that.

## Documentation
- [x] No Docs Needed: a fix

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.