### PR TITLE
fix(ui): agent settings not rendering

### DIFF
--- a/apps/agentstack-ui/src/modules/agents/components/detail/AgentSettingsView.tsx
+++ b/apps/agentstack-ui/src/modules/agents/components/detail/AgentSettingsView.tsx
@@ -11,9 +11,6 @@ import { MainContent } from '#components/layouts/MainContent.tsx';
 import { ViewHeader } from '#components/ViewHeader/ViewHeader.tsx';
 import { ViewStack } from '#components/ViewStack/ViewStack.tsx';
 import type { Agent } from '#modules/agents/api/types.ts';
-import { PlatformContextProvider } from '#modules/platform-context/contexts/PlatformContextProvider.tsx';
-import { useEnsurePlatformContext } from '#modules/platform-context/hooks/useEnsurePlatformContext.ts';
-import { A2AClientProvider } from '#modules/runs/contexts/a2a-client/A2AClientProvider.tsx';
 import { AgentSecretsProvider } from '#modules/runs/contexts/agent-secrets/AgentSecretsProvider.tsx';
 
 import { agentDetailFadeProps } from './AgentDetailView';
@@ -26,36 +23,24 @@ interface Props {
 
 export function AgentSettingsView({ agent }: Props) {
   return (
-    <PlatformContextProvider>
-      <AgentSettingsViewWithContext agent={agent} />
-    </PlatformContextProvider>
-  );
-}
+    <AgentSecretsProvider agent={agent}>
+      <MainContent>
+        <Container size="sm">
+          <ViewStack>
+            <AnimatePresence>
+              <motion.div {...agentDetailFadeProps} key="header">
+                <ViewHeader heading="Agent settings" />
+              </motion.div>
 
-function AgentSettingsViewWithContext({ agent }: Props) {
-  useEnsurePlatformContext(agent);
-
-  return (
-    <A2AClientProvider agent={agent}>
-      <AgentSecretsProvider agent={agent}>
-        <MainContent>
-          <Container size="sm">
-            <ViewStack>
-              <AnimatePresence>
-                <motion.div {...agentDetailFadeProps} key="header">
-                  <ViewHeader heading="Agent settings" />
-                </motion.div>
-
-                <motion.div {...agentDetailFadeProps} key="secrets">
-                  <AgentSection title="Secrets">
-                    <AgentSecrets />
-                  </AgentSection>
-                </motion.div>
-              </AnimatePresence>
-            </ViewStack>
-          </Container>
-        </MainContent>
-      </AgentSecretsProvider>
-    </A2AClientProvider>
+              <motion.div {...agentDetailFadeProps} key="secrets">
+                <AgentSection title="Secrets">
+                  <AgentSecrets />
+                </AgentSection>
+              </motion.div>
+            </AnimatePresence>
+          </ViewStack>
+        </Container>
+      </MainContent>
+    </AgentSecretsProvider>
   );
 }

--- a/apps/agentstack-ui/src/modules/runs/contexts/agent-secrets/AgentSecretsProvider.tsx
+++ b/apps/agentstack-ui/src/modules/runs/contexts/agent-secrets/AgentSecretsProvider.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { handleAgentCard } from 'agentstack-sdk';
 import type { PropsWithChildren } from 'react';
 import { useCallback, useMemo } from 'react';
 import { useLocalStorage } from 'usehooks-ts';
@@ -12,7 +13,6 @@ import type { Agent } from '#modules/agents/api/types.ts';
 import { useListVariables } from '#modules/variables/api/queries/useListVariables.ts';
 import { AGENT_SECRETS_SETTINGS_STORAGE_KEY } from '#utils/constants.ts';
 
-import { useA2AClient } from '../a2a-client';
 import { AgentSecretsContext } from './agent-secrets-context';
 import type { NonReadySecretDemand, ReadySecretDemand } from './types';
 
@@ -41,7 +41,6 @@ const secretsLocalStorageOptions = {
 };
 
 export function AgentSecretsProvider({ agent, children }: PropsWithChildren<Props>) {
-  const { agentClient } = useA2AClient();
   const [agentSecrets, setAgentSecrets] = useLocalStorage<Secrets>(
     AGENT_SECRETS_SETTINGS_STORAGE_KEY,
     {},
@@ -56,8 +55,9 @@ export function AgentSecretsProvider({ agent, children }: PropsWithChildren<Prop
   }, [agentSecrets, agent.provider.id]);
 
   const secretDemands = useMemo(() => {
-    return agentClient.demands.secretDemands ?? null;
-  }, [agentClient]);
+    const { demands } = handleAgentCard(agent);
+    return demands.secretDemands ?? null;
+  }, [agent]);
 
   const markModalAsSeen = useCallback(() => {
     setAgentSecrets((prev) => ({


### PR DESCRIPTION
## Summary
Fix UI issue where agent settings were not rendering. Uses agent card data already present in the API response to extract secret demands, avoiding the need for building a2a client.

## Linked Issues
Closes #2095 

## Documentation
- [x] No Docs Needed: a fix

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.