### PR TITLE
fix(ui): handle offline agents in sessions and run input

### DIFF
--- a/apps/agentstack-ui/src/modules/agents/api/queries/useListAgents.ts
+++ b/apps/agentstack-ui/src/modules/agents/api/queries/useListAgents.ts
@@ -4,7 +4,12 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import type { ListProvidersRequest, ListProvidersResponse } from 'agentstack-sdk';
+import {
+  type ListProvidersRequest,
+  type ListProvidersResponse,
+  ProviderStatus,
+  ProviderUnmanagedStatus,
+} from 'agentstack-sdk';
 
 import { buildAgent, isAgentUiSupported, sortAgentsByName, sortProvidersBy } from '#modules/agents/utils.ts';
 import { listProviders } from '#modules/providers/api/index.ts';
@@ -31,7 +36,9 @@ export function useListAgents({ includeUnsupportedUi, includeOffline, orderBy, i
       }
 
       if (!includeOffline) {
-        items = items.filter(({ state }) => state !== 'offline' && state !== 'error');
+        items = items.filter(
+          ({ state }) => state !== ProviderUnmanagedStatus.Offline && state !== ProviderStatus.Error,
+        );
       }
 
       let agents = items.map(buildAgent);

--- a/apps/agentstack-ui/src/modules/history/components/SessionsNav.tsx
+++ b/apps/agentstack-ui/src/modules/history/components/SessionsNav.tsx
@@ -22,7 +22,7 @@ interface Props {
 export function SessionsNav({ className }: Props) {
   const { contextId: contextIdUrl, providerId: providerIdUrl } = useParamsFromUrl();
 
-  const { data: agents, isLoading: isAgentsLoading } = useListAgents();
+  const { data: agents, isLoading: isAgentsLoading } = useListAgents({ includeOffline: true });
   const { data, isLoading, isFetching, hasNextPage, fetchNextPage } = useListContexts({
     query: { ...LIST_CONTEXTS_DEFAULT_QUERY, provider_id: providerIdUrl },
   });

--- a/apps/agentstack-ui/src/modules/providers/components/DeleteProviderButton.tsx
+++ b/apps/agentstack-ui/src/modules/providers/components/DeleteProviderButton.tsx
@@ -21,7 +21,7 @@ export function DeleteProviderButton({ provider }: Props) {
   return (
     <DeleteButton
       entityName={source}
-      entityLabel="provider"
+      entityLabel="provider and related sessions"
       isPending={isPending}
       onSubmit={() => deleteProvider({ id })}
     />

--- a/apps/agentstack-ui/src/modules/runs/components/RunInput.module.scss
+++ b/apps/agentstack-ui/src/modules/runs/components/RunInput.module.scss
@@ -11,6 +11,11 @@
   &:has(textarea:focus-visible) {
     border-color: $text-dark;
   }
+
+  &.isDisabled {
+    background-color: $field;
+    cursor: not-allowed;
+  }
 }
 
 .textarea {


### PR DESCRIPTION
## Summary
- Updated agent filtering to use SDK enums and included offline agents in SessionsNav resolution, so existing sessions remain visible when the agent is offline. However, offline agents are hidden from the main agents list and can only be reached via a direct URL.
- Updated RunInput to detect offline providers and disable interaction (textarea submit + settings/file/model controls), with a clear offline placeholder/state styling.
- Adjusted provider deletion confirmation copy to indicate that related sessions are expected to be removed.

## Linked Issues
Refs: https://github.com/i-am-bee/agentstack/issues/1566


## Documentation
- [x] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.