### PR TITLE
fix(ui): force duration update for elapsed time

### DIFF
--- a/apps/agentstack-ui/src/modules/runs/components/RunElapsedTime.tsx
+++ b/apps/agentstack-ui/src/modules/runs/components/RunElapsedTime.tsx
@@ -16,13 +16,13 @@ interface Props {
 }
 
 export function RunElapsedTime({ stats, className }: Props) {
-  const [, forceRerender] = useState(0);
+  const [now, setNow] = useState(Date.now());
 
   useEffect(() => {
     if (!stats?.startTime || stats.endTime) return;
 
     const interval = setInterval(() => {
-      forceRerender((prev) => prev + 1);
+      setNow(Date.now());
     }, 1000 / 24); // refresh at standard frame rate for smooth increments
 
     return () => clearInterval(interval);
@@ -31,7 +31,7 @@ export function RunElapsedTime({ stats, className }: Props) {
   if (!stats?.startTime) return null;
 
   const { startTime, endTime } = stats;
-  const duration = runDuration((endTime || Date.now()) - startTime);
+  const duration = runDuration((endTime || now) - startTime);
 
   return <span className={clsx(classes.root, className)}>{duration}</span>;
 }


### PR DESCRIPTION
## Summary
Fixes an issue with wrong automatic memoization of duration after update to React 19.

## Linked Issues

## Documentation
- [x] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.