### PR TITLE
fix(cli): forward port 4318 (OTLP) from VM to host

### DIFF
--- a/apps/agentstack-cli/src/agentstack_cli/commands/platform.py
+++ b/apps/agentstack-cli/src/agentstack_cli/commands/platform.py
@@ -704,7 +704,7 @@ async def start_cmd(
                     systemctl daemon-reload
                     kubectl --kubeconfig=/kubeconfig get svc -n default -o 'jsonpath={range .items[*]}{.metadata.name}{":"}{.spec.ports[*].port}{"\\n"}{end}' | while IFS=: read svc ports; do
                         for port in $ports; do
-                            if ([ "$port" -ge 8333 ] && [ "$port" -le 8399 ]) || [ "$port" -eq 4318 ]; then
+                            if [[ ( "$port" -ge 8333 && "$port" -le 8399 ) || "$port" -eq 4318 ]]; then
                                 systemctl start "kubectl-port-forward@${svc}:${port}" &
                             fi
                         done


### PR DESCRIPTION
## Summary
- Add port 4318 to the VM-to-host port forwarding rules so the OpenTelemetry (OTLP) collector endpoint is accessible from the host

## Test plan
- [ ] Verify `platform start` forwards port 4318 alongside the 8333-8399 range