### PR TITLE
chore: add .claude/worktrees to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,4 @@ mise.local.toml
 
 # Claude
 .claude/tasks
+.claude/worktrees


### PR DESCRIPTION
Claude Code creates local worktrees under `.claude/worktrees/` for isolated development. These are ephemeral, developer-local artifacts and should not be tracked in version control.

- [x] No Docs Needed: