### PR TITLE
fix(mise): restore python.uv_venv_auto = true setting

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -26,7 +26,8 @@ gum = "latest"
 hadolint = "latest"
 
 [settings]
-experimental = true # for task_templates
+experimental = true # for task_templates and python.uv_venv_auto
+python.uv_venv_auto = true
 task.disable_spec_from_run_scripts = true # opt-in to new task behavior
 
 [hooks]


### PR DESCRIPTION
## Summary

Restores the `python.uv_venv_auto = true` setting in `mise.toml` that was previously removed.

This setting allows running `python` or `pytest` directly inside agent project directories without needing to prefix commands with `uv run`. Agents rely on this behavior, and it improves the developer experience when working inside Python project folders.

- [x] No Docs Needed:
