### PR TITLE
fix(sdk): strip trailing slash from platform_url to prevent double slash in api_base

### DIFF
--- a/apps/agentstack-sdk-py/src/agentstack_sdk/a2a/extensions/services/embedding.py
+++ b/apps/agentstack-sdk-py/src/agentstack_sdk/a2a/extensions/services/embedding.py
@@ -109,7 +109,7 @@ class EmbeddingServiceExtensionServer(
             return
 
         for fullfilment in self.data.embedding_fulfillments.values():
-            platform_url = str(get_platform_client().base_url)
+            platform_url = str(get_platform_client().base_url).rstrip("/")
             fullfilment.api_base = re.sub("{platform_url}", platform_url, fullfilment.api_base)
 
 

--- a/apps/agentstack-sdk-py/src/agentstack_sdk/a2a/extensions/services/llm.py
+++ b/apps/agentstack-sdk-py/src/agentstack_sdk/a2a/extensions/services/llm.py
@@ -107,7 +107,7 @@ class LLMServiceExtensionServer(BaseExtensionServer[LLMServiceExtensionSpec, LLM
             return
 
         for fullfilment in self.data.llm_fulfillments.values():
-            platform_url = str(get_platform_client().base_url)
+            platform_url = str(get_platform_client().base_url).rstrip("/")
             fullfilment.api_base = re.sub("{platform_url}", platform_url, fullfilment.api_base)
 
 

--- a/apps/agentstack-sdk-py/src/agentstack_sdk/a2a/extensions/services/mcp.py
+++ b/apps/agentstack-sdk-py/src/agentstack_sdk/a2a/extensions/services/mcp.py
@@ -138,7 +138,7 @@ class MCPServiceExtensionServer(BaseExtensionServer[MCPServiceExtensionSpec, MCP
         if not self.data:
             return
 
-        platform_url = str(get_platform_client().base_url)
+        platform_url = str(get_platform_client().base_url).rstrip("/")
         for fullfilment in self.data.mcp_fulfillments.values():
             if fullfilment.transport.type == "streamable_http":
                 try:


### PR DESCRIPTION
## Problem

When the LLM/embedding extension server substitutes `{platform_url}` in the `api_base` template, `httpx` adds a trailing slash to `base_url`. This caused the resulting URL to have a double slash:

```
http://127.0.0.1:8333//api/v1/openai/
```

instead of the expected:

```
http://127.0.0.1:8333/api/v1/openai/
```

## Fix

Strip the trailing slash from the `platform_url` string before performing the `{platform_url}` substitution in `llm.py`, `embedding.py`, and `mcp.py`.

- [x] No Docs Needed