### PR TITLE
fix(helm): generate sqlConnectionSuperuser secret for external databases

### DIFF
--- a/helm/templates/config/secret.yaml
+++ b/helm/templates/config/secret.yaml
@@ -35,7 +35,7 @@ data:
        (include "agentstack.databaseName" .)
        | b64enc | quote
   }}
-  {{- if and .Values.postgresql.enabled .Values.postgresql.auth.enablePostgresUser }}
+  {{- if or (and .Values.postgresql.enabled .Values.postgresql.auth.enablePostgresUser) (and (not .Values.postgresql.enabled) .Values.externalDatabase.adminUser .Values.externalDatabase.adminPassword) }}
   sqlConnectionSuperuser: {{ printf "postgresql+asyncpg://%s:%s@%s:%s/%s"
        (include "agentstack.databaseAdminUser" .)
        (include "agentstack.databaseAdminPassword" .)


### PR DESCRIPTION
## Summary
- When using an external database with `adminUser`/`adminPassword` configured, the `sqlConnectionSuperuser` key was not being added to the `agentstack-secret`. This caused the `createVectorDbExtension` init container to fail with `couldn't find key sqlConnectionSuperuser in Secret`.
- The condition in `helm/templates/config/secret.yaml` now also generates the superuser connection string when using an external database with admin credentials provided.

## Test plan
- [ ] Deploy with external database and `adminUser`/`adminPassword` set, verify `sqlConnectionSuperuser` key exists in the secret
- [ ] Deploy with internal PostgreSQL, verify behavior unchanged
- [ ] Deploy with external database without admin credentials, verify `sqlConnectionSuperuser` is not generated

- [x] No Docs Needed