### PR TITLE
chore: remove invalid `*.py,cover` pattern from .aiignore

### DIFF
--- a/.aiignore
+++ b/.aiignore
@@ -84,7 +84,6 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *.cover
-*.py,cover
 .hypothesis/
 .pytest_cache/
 cover/


### PR DESCRIPTION
## Summary
- Removes the `*.py,cover` pattern from `.aiignore` as it contains a comma which makes it an invalid glob pattern

## Test plan
- [x] Verify no other changes are included