### PR TITLE
fix: improve agent startup and error messages in CLI

### DIFF
--- a/apps/agentstack-cli/src/agentstack_cli/commands/agent.py
+++ b/apps/agentstack-cli/src/agentstack_cli/commands/agent.py
@@ -433,10 +433,11 @@ def search_path_match_providers(search_path: str, providers: list[Provider]) -> 
 
 def select_provider(search_path: str, providers: list[Provider]):
     provider_candidates = search_path_match_providers(search_path, providers)
-    if len(provider_candidates) != 1:
-        provider_candidates = [f"  - {c}" for c in provider_candidates]
-        remove_providers_detail = ":\n" + "\n".join(provider_candidates) if provider_candidates else ""
-        raise ValueError(f"{len(provider_candidates)} matching agents{remove_providers_detail}")
+    if len(provider_candidates) == 0:
+        raise ValueError(f"No agents matched '{search_path}'")
+    if len(provider_candidates) > 1:
+        candidates_detail = "\n".join(f"  - {c}" for c in provider_candidates)
+        raise ValueError(f"Multiple agents matched '{search_path}':\n{candidates_detail}")
     [selected_provider] = provider_candidates.values()
     return selected_provider
 
@@ -520,10 +521,10 @@ async def stream_logs(
     ],
 ):
     """Stream agent provider logs. [Admin only]"""
-    announce_server_action(f"Streaming logs for '{search_path}' from")
     async with configuration.use_platform_client():
-        provider = select_provider(search_path, await Provider.list()).id
-        async for message in Provider.stream_logs(provider):
+        provider = select_provider(search_path, await Provider.list())
+        announce_server_action(f"Streaming logs for '{provider.agent_card.name}' from")
+        async for message in Provider.stream_logs(provider.id):
             print_log(message, ansi_mode=True)
 
 

--- a/apps/agentstack-server/src/agentstack_server/infrastructure/kubernetes/provider_deployment_manager.py
+++ b/apps/agentstack-server/src/agentstack_server/infrastructure/kubernetes/provider_deployment_manager.py
@@ -265,7 +265,7 @@ class KubernetesProviderDeploymentManager(IProviderDeploymentManager):
                     except kr8s.NotFoundError:
                         ...
                     if not missing_logged:
-                        logs_container.add_stdout("Provider is not running, run a query to start it up...")
+                        logs_container.add_stdout("Agent is starting up...")
                     missing_logged = True
                     await asyncio.sleep(1)
 


### PR DESCRIPTION
## Summary
- **Better error for non-existent agents**: `agentstack logs chata` now shows `No agents matched 'chata'` instead of `ValueError: 0 matching agents`
- **Better error for ambiguous matches**: Shows `Multiple agents matched '<name>'` with a list of candidates
- **Fix premature announce**: "Streaming logs for..." message now appears only after the agent is found, and shows the actual agent name instead of the search string
- **Better startup message**: Changed "Provider is not running, run a query to start it up..." to "Agent is starting up..."

## Test plan
- [x] `mise run check` passes
- [x] No Docs Needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)