### PR TITLE
Fix CVE-2025-58754: Upgrade axios to patch DoS vulnerability

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ catalogs:
       version: 11.49.0
     '@carbon/react':
       specifier: ^1.101.0
-      version: 1.101.0
+      version: 1.102.0
     '@carbon/styles':
       specifier: ^1.100.0
       version: 1.101.0
@@ -78,6 +78,7 @@ catalogs:
 
 overrides:
   path-to-regexp@<0.1.10: 0.1.10
+  axios@<1.12.0: '>=1.12.0'
 
 importers:
 
@@ -4420,9 +4421,6 @@ packages:
   axe-core@4.11.1:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
-
-  axios@1.10.0:
-    resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
 
   axios@1.13.2:
     resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
@@ -11207,7 +11205,7 @@ snapshots:
 
   '@mintlify/models@0.0.255':
     dependencies:
-      axios: 1.10.0
+      axios: 1.13.2
       openapi-types: 12.1.3
     transitivePeerDependencies:
       - debug
@@ -14040,14 +14038,6 @@ snapshots:
   avsc@5.7.9: {}
 
   axe-core@4.11.1: {}
-
-  axios@1.10.0:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   axios@1.13.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,9 @@ overrides:
   # Fix CVE-2024-45296 / GHSA-9wv6-86v2-598j: path-to-regexp ReDoS vulnerability
   # Transitive via mintlify -> @mintlify/previewing -> express@4.18.2
   "path-to-regexp@<0.1.10": "0.1.10"
+  # Fix CVE-2025-58754 / GHSA-4hjh-wcwx-xvwj: axios DoS vulnerability via data: URI
+  # Transitive via mintlify -> @mintlify/scraping -> @mintlify/common -> @mintlify/models
+  "axios@<1.12.0": ">=1.12.0"
 
 packages:
   - apps/agentstack-ui


### PR DESCRIPTION
## Summary
Upgrades axios to version 1.12.0 or higher to fix CVE-2025-58754 / GHSA-4hjh-wcwx-xvwj, a denial of service vulnerability via data: URI. This dependency is pulled in transitively through the mintlify dependency chain.

## Linked Issues
<!-- Add issue reference if applicable -->

## Documentation
- [x] No Docs Needed: This is a security patch with no user-facing changes or API modifications.

https://claude.ai/code/session_0141PZwEdnJ66b38QFWNtgrY