### PR TITLE
fix(keycloak-theme): force build to resolve React from package path

### DIFF
--- a/apps/keycloak-theme/vite.config.ts
+++ b/apps/keycloak-theme/vite.config.ts
@@ -5,6 +5,7 @@
 
 import react from '@vitejs/plugin-react';
 import { keycloakify } from 'keycloakify/vite-plugin';
+import { createRequire } from 'module';
 import path from 'path';
 import { defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
@@ -12,6 +13,9 @@ import svgr from 'vite-plugin-svgr';
 
 const THEME_NAME_AGENTSTACK = 'agentstack';
 const THEME_NAME_AGENTSTACK_SSO = 'agentstack-sso';
+const require = createRequire(import.meta.url);
+
+const resolvePackageDir = (packageName: string) => path.dirname(require.resolve(`${packageName}/package.json`));
 
 export default defineConfig({
   define: {
@@ -54,10 +58,10 @@ export default defineConfig({
   resolve: {
     dedupe: ['react', 'react-dom'],
     alias: {
-      react: path.resolve(__dirname, 'node_modules/react'),
-      'react/jsx-runtime': path.resolve(__dirname, 'node_modules/react/jsx-runtime.js'),
-      'react/jsx-dev-runtime': path.resolve(__dirname, 'node_modules/react/jsx-dev-runtime.js'),
-      'react-dom': path.resolve(__dirname, 'node_modules/react-dom'),
+      react: resolvePackageDir('react'),
+      'react/jsx-runtime': require.resolve('react/jsx-runtime'),
+      'react/jsx-dev-runtime': require.resolve('react/jsx-dev-runtime'),
+      'react-dom': resolvePackageDir('react-dom'),
       styles: path.resolve(__dirname, '../agentstack-ui/src/styles'),
     },
   },


### PR DESCRIPTION
## Summary
Fixes Keycloak login blank page caused by mixed React runtimes in the keycloak-theme build.
The Vite config now dedupes and aliases react, react-dom and JSX runtime imports to the local package path, ensuring a single runtime in bundled assets - this keeps both custom-themed pages and Keycloakify fallback pages working consistently in local and platform deployments.

## Linked Issues
Closes #2347 

## Documentation
- [x] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.