### PR TITLE
fix(skill): set suggested model from original agent

### DIFF
--- a/skills/agentstack-wrapper/SKILL.md
+++ b/skills/agentstack-wrapper/SKILL.md
@@ -111,6 +111,7 @@ Task Progress:
 - [ ] Step 3: Add and Install Dependencies
 - [ ] Step 4: Create the Server Wrapper & Entrypoint
 - [ ] Step 5: Wire LLM / Services via Extensions (requires reading docs)
+- [ ] Step 5a: Set suggested model to match the model used in the original agent
 - [ ] Step 6: Implement Error Handling (requires reading docs)
 - [ ] Step 7: Map Forms (if applicable) (requires reading docs)
 - [ ] Step 7b: Adapt File Inputs (if applicable) (requires reading docs)
@@ -178,6 +179,8 @@ This classification determines:
 ## Step 5 – Wire LLM / Services via Extensions
 
 **Read [references/llm-services.md](reference/llm-services.md) and follow it completely for Step 5.**
+
+Set the `suggested` model in `LLMServiceExtensionSpec.single_demand()` to the same model used in the original agent.
 
 ---
 

--- a/skills/agentstack-wrapper/references/llm-services.md
+++ b/skills/agentstack-wrapper/references/llm-services.md
@@ -24,3 +24,4 @@ See the [chat agent](https://github.com/i-am-bee/agentstack/blob/main/agents/cha
 - Do not skip the docs/examples and improvise imports or extension usage.
 - Do not read model/API key/base URL from env vars when LLM extension is available.
 - Do not rewrite `api_base` heuristically unless the official docs explicitly require it.
+- Do not use a generic model as `suggested` — use the same model identifier as the original agent.


### PR DESCRIPTION
## Problem

When wrapping an agent, the skill used a generic model as the `suggested` hint in `LLMServiceExtensionSpec.single_demand()`. The platform may allocate a different model if the suggested one is unavailable, which can cause runtime failures.

## Changes

- **`references/llm-services.md`**: Add Anti-Pattern bullet — do not use a generic model as `suggested`; use the same model identifier as the original agent.
- **`SKILL.md`**: Add Step 5a checklist item — set `suggested` model to match the model used in the original agent.