### PR TITLE
feat(agentstack-server): add ECR registry compatibility

### DIFF
--- a/apps/agentstack-server/src/agentstack_server/utils/docker.py
+++ b/apps/agentstack-server/src/agentstack_server/utils/docker.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 from datetime import timedelta
 from enum import StrEnum
@@ -31,12 +32,37 @@ class RegistryPermissions(StrEnum):
     PUSH = "push"
 
 
-AUTH_URL_PER_REGISTRY = {
-    "ghcr.io": "https://ghcr.io/token?service=ghcr.io&scope=repository:{repository}:{permissions}",
-    "icr.io": "https://icr.io/oauth/token?service=registry&scope=repository:{repository}:{permissions}",
-    "us.icr.io": "https://us.icr.io/oauth/token?service=registry&scope=repository:{repository}:{permissions}",
-    "docker.io": "https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repository}:{permissions}",
-    "registry-1.docker.io": "https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repository}:{permissions}",
+class RegistryAuthScheme(StrEnum):
+    BEARER = "bearer"
+    BASIC = "basic"
+
+
+class RegistryAuthInfo(NamedTuple):
+    scheme: RegistryAuthScheme
+    token_url: str | None  # None for Basic auth registries
+
+
+AUTH_URL_PER_REGISTRY: dict[str, RegistryAuthInfo] = {
+    "ghcr.io": RegistryAuthInfo(
+        RegistryAuthScheme.BEARER,
+        "https://ghcr.io/token?service=ghcr.io&scope=repository:{repository}:{permissions}",
+    ),
+    "icr.io": RegistryAuthInfo(
+        RegistryAuthScheme.BEARER,
+        "https://icr.io/oauth/token?service=registry&scope=repository:{repository}:{permissions}",
+    ),
+    "us.icr.io": RegistryAuthInfo(
+        RegistryAuthScheme.BEARER,
+        "https://us.icr.io/oauth/token?service=registry&scope=repository:{repository}:{permissions}",
+    ),
+    "docker.io": RegistryAuthInfo(
+        RegistryAuthScheme.BEARER,
+        "https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repository}:{permissions}",
+    ),
+    "registry-1.docker.io": RegistryAuthInfo(
+        RegistryAuthScheme.BEARER,
+        "https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repository}:{permissions}",
+    ),
 }
 
 base_headers = {
@@ -147,30 +173,41 @@ class DockerImageID(RootModel[str]):
         digest = f"@{self.digest}" if self.digest else ""
         return f"{self.base}:{self.tag}{digest}"
 
-    async def get_registry_auth_endpoint(self) -> str | None:
+    async def get_registry_auth_info(self) -> RegistryAuthInfo | None:
         if self.registry not in AUTH_URL_PER_REGISTRY:
             async with httpx.AsyncClient() as client:
                 registry_resp = await client.get(self.get_manifest_url, follow_redirects=True)
                 header = registry_resp.headers.get("www-authenticate")
             if not header:
-                return
-            if not (match := re.match(r"(\w+)\s+(.*)", header)):
+                return None
+            if not (match := re.match(r"(\w+)\s*(.*)", header)):
                 raise ValueError(f"Invalid www authenticate header: {header}")
-            _auth_scheme, params_str = match.groups()
-            params = {}
-            for param in re.finditer(r'(\w+)="([^"]*)"', params_str):
-                key, value = param.groups()
-                params[key] = value
-            auth_url = f"{params['realm']}?service={params['service']}&scope=repository:{{repository}}:{{permissions}}"
-            AUTH_URL_PER_REGISTRY[self.registry] = auth_url
+            auth_scheme, params_str = match.groups()
+
+            if auth_scheme.lower() == "basic":
+                AUTH_URL_PER_REGISTRY[self.registry] = RegistryAuthInfo(RegistryAuthScheme.BASIC, None)
+            else:
+                params = {}
+                for param in re.finditer(r'(\w+)="([^"]*)"', params_str):
+                    key, value = param.groups()
+                    params[key] = value
+                auth_url = (
+                    f"{params['realm']}?service={params['service']}&scope=repository:{{repository}}:{{permissions}}"
+                )
+                AUTH_URL_PER_REGISTRY[self.registry] = RegistryAuthInfo(RegistryAuthScheme.BEARER, auth_url)
 
         return AUTH_URL_PER_REGISTRY[self.registry]
+
+    def _basic_auth_header(self) -> dict[str, str]:
+        if basic_auth := self.registry_config.basic_auth_str:
+            return {"Authorization": f"Basic {basic_auth}"}
+        return {}
 
     async def get_manifest(self) -> ManifestResponse:
         headers = base_headers.copy()
 
-        if token := await get_registry_token(docker_image_id=self, permissions=(RegistryPermissions.PULL,)):
-            headers["Authorization"] = f"Bearer {token}"
+        if auth_header := await get_registry_auth_header(docker_image_id=self, permissions=(RegistryPermissions.PULL,)):
+            headers["Authorization"] = auth_header
 
         async with httpx.AsyncClient() as client:
             manifest_resp = await client.get(self.get_manifest_url, headers=headers, follow_redirects=True)
@@ -178,9 +215,16 @@ class DockerImageID(RootModel[str]):
             if manifest_resp.status_code != 200:
                 raise Exception(f"Failed to get manifest: {manifest_resp.status_code}, {manifest_resp.text}")
 
+            manifest_json = manifest_resp.json()
+            digest = manifest_resp.headers.get("Docker-Content-Digest")
+            if not digest:
+                # Some registries (e.g. ECR) don't return Docker-Content-Digest header,
+                # fall back to computing it from the response body
+                digest = "sha256:" + hashlib.sha256(manifest_resp.content).hexdigest()
+
             return ManifestResponse(
-                manifest=manifest_resp.raise_for_status().json(),
-                digest=manifest_resp.headers["Docker-Content-Digest"],
+                manifest=manifest_json,
+                digest=digest,
             )
 
     async def resolve_version(self) -> ResolvedDockerImageID:
@@ -217,7 +261,8 @@ class ResolvedDockerImageID(BaseModel):
         manifest = await self.get_manifest()
 
         headers = base_headers.copy()
-        headers["Authorization"] = f"Bearer {await get_registry_token(docker_image_id=self.image_id)}"
+        if auth_header := await get_registry_auth_header(docker_image_id=self.image_id):
+            headers["Authorization"] = auth_header
 
         async with httpx.AsyncClient() as client:
             if "manifests" in manifest:
@@ -243,32 +288,41 @@ class ResolvedDockerImageID(BaseModel):
 
 
 @alru_cache(ttl=timedelta(minutes=5).total_seconds())
-async def get_registry_token(
+async def get_registry_auth_header(
     *,
     docker_image_id: DockerImageID,
     permissions: tuple[RegistryPermissions] = (RegistryPermissions.PULL,),
 ) -> str | None:
+    """Get the Authorization header value for a registry request.
+
+    Returns a "Bearer <token>" or "Basic <credentials>" string, or None if no auth is needed.
+    """
     try:
-        token_endpoint = await docker_image_id.get_registry_auth_endpoint()
+        auth_info = await docker_image_id.get_registry_auth_info()
     except Exception as ex:
         raise Exception(
             f"Image registry does not exist or is not accessible: {docker_image_id.get_manifest_url}"
         ) from ex
 
-    if token_endpoint:
+    if not auth_info:
+        return None
+
+    # Registries like ECR use Basic auth directly — no token exchange needed
+    if auth_info.scheme == RegistryAuthScheme.BASIC:
+        return docker_image_id._basic_auth_header().get("Authorization")
+
+    # Bearer token flow (Docker Hub, GHCR, etc.)
+    if auth_info.token_url:
+        token_url = auth_info.token_url.format(
+            repository=docker_image_id.repository, permissions=",".join(str(p) for p in permissions)
+        )
         async with httpx.AsyncClient() as client:
-            if token_endpoint:
-                token_endpoint = token_endpoint.format(
-                    repository=docker_image_id.repository, permissions=",".join(str(p) for p in permissions)
-                )
-                auth_resp = await client.get(
-                    token_endpoint,
-                    follow_redirects=True,
-                    headers={"Authorization": f"Basic {docker_image_id.registry_config.basic_auth_str}"}
-                    if docker_image_id.registry_config.basic_auth_str
-                    else {},
-                )
-                if auth_resp.status_code != 200:
-                    raise Exception(f"Failed to authenticate: {auth_resp.status_code}, {auth_resp.text}")
-                return auth_resp.json()["token"]
+            auth_resp = await client.get(
+                token_url,
+                follow_redirects=True,
+                headers=docker_image_id._basic_auth_header(),
+            )
+            if auth_resp.status_code != 200:
+                raise Exception(f"Failed to authenticate: {auth_resp.status_code}, {auth_resp.text}")
+            return f"Bearer {auth_resp.json()['token']}"
     return None

--- a/apps/agentstack-server/tests/integration/utils/test_docker.py
+++ b/apps/agentstack-server/tests/integration/utils/test_docker.py
@@ -33,6 +33,7 @@ def configuration():
         DockerImageID(root="redis:latest"),
         DockerImageID(root="icr.io/ibm-messaging/mq:latest"),
         DockerImageID(root="registry.goharbor.io/nightly/goharbor/harbor-log:v1.10.0"),
+        DockerImageID(root="public.ecr.aws/docker/library/redis:latest"),
     ],
 )
 async def test_get_image_labels(image, configuration):


### PR DESCRIPTION
# TODO: autogenerated

Ref: #2375

## Summary
- ECR (Amazon Elastic Container Registry) and other registries using Basic auth were returning 404/401 errors because the code assumed all registries use the OAuth2 Bearer token exchange flow
- Added detection of `Basic` vs `Bearer` auth scheme from the `www-authenticate` response header
- For Basic auth registries (e.g. ECR), credentials are now sent directly on API requests instead of attempting a token exchange
- Added fallback for missing `Docker-Content-Digest` header (ECR doesn't always return it) by computing the digest from the response body

## Test plan
- [x] Unit tests pass (`mise run agentstack-server:test:unit` — 100 passed)
- [x] Lint/format checks pass
- [ ] Manual test with an ECR registry to verify image resolution works end-to-end
- [x] No Docs Needed