### PR TITLE
feat(connectors): replace access_token with arbitrary headers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,3 +16,4 @@ All commits must be signed off for DCO compliance (`git commit --signoff`).
 - When working in agentstack-server make sure you always test the behaviour using the agentstack-server debugging approach
 - All testing and linting can be done via `mise run check`
 - Formatting can be fixed via `mise run fix`
+- Breaking API changes must be documented in `docs/development/reference/changelog.mdx`

--- a/apps/agentstack-cli/src/agentstack_cli/commands/connector.py
+++ b/apps/agentstack-cli/src/agentstack_cli/commands/connector.py
@@ -221,8 +221,21 @@ async def get_connector(
 @app.command("connect")
 async def connect(
     search_path: typing.Annotated[str, typer.Argument(help="Short ID or connector url, supports partial matching")],
+    header: typing.Annotated[
+        list[str] | None,
+        typer.Option("--header", "-H", help="Header to forward to the MCP server (format: 'Name: Value'). Can be repeated."),
+    ] = None,
 ) -> None:
     """Connect a connector (e.g., start OAuth flow)."""
+    headers = None
+    if header:
+        headers = {}
+        for h in header:
+            name, _, value = h.partition(":")
+            if not value:
+                raise typer.BadParameter(f"Invalid header format '{h}', expected 'Name: Value'")
+            headers[name.strip()] = value.strip()
+
     async with configuration.use_platform_client():
         selected_connector = await select_connector(search_path)
         if not selected_connector:
@@ -230,7 +243,7 @@ async def connect(
 
         try:
             with console.status("Connecting connector...", spinner="dots"):
-                connector = await selected_connector.connect()
+                connector = await selected_connector.connect(headers=headers)
                 connector = await connector.wait_for_state(state=ConnectorState.connected)
 
             console.success(

--- a/apps/agentstack-sdk-py/src/agentstack_sdk/platform/connector.py
+++ b/apps/agentstack-sdk-py/src/agentstack_sdk/platform/connector.py
@@ -220,7 +220,7 @@ class Connector(pydantic.BaseModel):
         self: "Connector" | UuidStr,
         *,
         redirect_url: AnyUrl | str | None = None,
-        access_token: str | None = None,
+        headers: dict[str, str] | None = None,
         client: PlatformClient | None = None,
     ) -> "Connector":
         """
@@ -231,7 +231,7 @@ class Connector(pydantic.BaseModel):
 
         Args:
             redirect_url: OAuth redirect URL (optional)
-            access_token: OAuth access token (optional)
+            headers: Custom headers to forward to the MCP server (optional)
             client: Optional PlatformClient instance
 
         Returns:
@@ -243,7 +243,7 @@ class Connector(pydantic.BaseModel):
                 url=f"/api/v1/connectors/{connector_id}/connect",
                 json={
                     "redirect_url": str(redirect_url) if redirect_url else None,
-                    "access_token": access_token,
+                    "headers": headers,
                 },
             )
             response.raise_for_status()

--- a/apps/agentstack-sdk-ts/src/client/api/connectors/schemas.ts
+++ b/apps/agentstack-sdk-ts/src/client/api/connectors/schemas.ts
@@ -55,6 +55,7 @@ export const deleteConnectorResponseSchema = z.null();
 export const connectConnectorRequestSchema = z.object({
   connector_id: z.string(),
   redirect_url: z.string().nullish(),
+  headers: z.record(z.string(), z.string()).nullish(),
 });
 
 export const connectConnectorResponseSchema = connectorSchema;

--- a/apps/agentstack-server/src/agentstack_server/api/routes/connectors.py
+++ b/apps/agentstack-server/src/agentstack_server/api/routes/connectors.py
@@ -99,7 +99,7 @@ async def connect_connector(
             user=user.user,
             redirect_url=connect_request.redirect_url,
             callback_uri=str(request.url_for(oauth_callback.__name__)),
-            access_token=connect_request.access_token,
+            headers=connect_request.headers,
         )
     )
 

--- a/apps/agentstack-server/src/agentstack_server/api/schema/connector.py
+++ b/apps/agentstack-server/src/agentstack_server/api/schema/connector.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Annotated, Literal
 from uuid import UUID
 
-from pydantic import AnyUrl, AwareDatetime, BaseModel, Field
+from pydantic import AnyUrl, AwareDatetime, BaseModel, Field, field_validator
 
 from agentstack_server.domain.models.common import Metadata
 from agentstack_server.domain.models.connector import ConnectorState
@@ -43,9 +43,40 @@ class ConnectorResponse(BaseModel):
     created_by: UUID
 
 
+_BLOCKED_HEADERS = frozenset({
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "forwarded",
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-forwarded-port",
+    "via",
+    "host",
+    "cookie",
+    "set-cookie",
+})
+
+
 class ConnectorConnectRequest(BaseModel):
     redirect_url: AnyUrl | None = None
-    access_token: str | None = None
+    headers: dict[str, str] | None = None
+
+    @field_validator("headers")
+    @classmethod
+    def validate_headers(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is None:
+            return None
+        blocked = {k for k in v if k.lower() in _BLOCKED_HEADERS}
+        if blocked:
+            raise ValueError(f"Blocked header(s): {', '.join(sorted(blocked))}")
+        return v
 
 
 class ConnectorPresetResponse(BaseModel):

--- a/apps/agentstack-server/src/agentstack_server/domain/models/connector.py
+++ b/apps/agentstack-server/src/agentstack_server/domain/models/connector.py
@@ -48,6 +48,7 @@ class Authorization(BaseModel):
     flow: AuthFlow | None = None
     token: Token | None = None
     token_endpoint: AnyUrl | None = None
+    headers: dict[str, str] | None = None
 
 
 class ConnectorState(StrEnum):

--- a/apps/agentstack-server/src/agentstack_server/service_layer/services/connector.py
+++ b/apps/agentstack-server/src/agentstack_server/service_layer/services/connector.py
@@ -211,6 +211,7 @@ class ConnectorService:
 
         if connector.auth:
             connector.auth.flow = None
+            connector.auth.headers = None
         connector.transition(
             state=ConnectorState.disconnected, disconnect_reason="Client request", disconnect_permanent=True
         )

--- a/apps/agentstack-server/src/agentstack_server/service_layer/services/connector.py
+++ b/apps/agentstack-server/src/agentstack_server/service_layer/services/connector.py
@@ -25,7 +25,6 @@ from agentstack_server.domain.models.connector import (
     Authorization,
     Connector,
     ConnectorState,
-    Token,
 )
 from agentstack_server.domain.models.user import User
 from agentstack_server.exceptions import PlatformError
@@ -168,14 +167,14 @@ class ConnectorService:
         callback_uri: str,
         redirect_url: AnyUrl | None = None,
         user: User | None = None,
-        access_token: str | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Connector:
         async with self._uow() as uow:
             connector = await uow.connectors.get(connector_id=connector_id, user_id=user.id if user else None)
-        if access_token:
+        if headers:
             if not connector.auth:
                 connector.auth = Authorization()
-            connector.auth.token = Token(access_token=access_token, token_type="bearer")
+            connector.auth.headers = headers
 
         if self._managed_mcp.is_managed(connector=connector) and (preset := self._find_preset(url=connector.url)):
             await self._managed_mcp.deploy(connector=connector, preset=preset)
@@ -328,14 +327,12 @@ class ConnectorService:
     async def mcp_proxy(self, *, connector_id: UUID, request: Request, user: User | None = None):
         connector = await self.read_connector(connector_id=connector_id, user=user)
 
-        auth_headers = {}
-        if (
-            connector.auth
-            and connector.state == ConnectorState.connected
-            and connector.auth.token
-            and connector.auth.token.token_type == "bearer"
-        ):
-            auth_headers["authorization"] = f"Bearer {connector.auth.token.access_token}"
+        auth_headers: dict[str, str] = {}
+        if connector.auth and connector.state == ConnectorState.connected:
+            if connector.auth.headers:
+                auth_headers.update(connector.auth.headers)
+            if connector.auth.token and connector.auth.token.token_type == "bearer":
+                auth_headers["authorization"] = f"Bearer {connector.auth.token.access_token}"
 
         exit_stack = AsyncExitStack()
         try:

--- a/apps/agentstack-server/src/agentstack_server/service_layer/services/external_mcp_service.py
+++ b/apps/agentstack-server/src/agentstack_server/service_layer/services/external_mcp_service.py
@@ -94,14 +94,15 @@ class ExternalMcpService:
     def create_http_client(
         self, *, connector: Connector, headers: dict[str, str] | None = None, timeout: int | None = None
     ) -> httpx.AsyncClient:
+        merged_headers = {**(connector.auth.headers or {}), **(headers or {})} if connector.auth else headers
         if not connector.auth or not connector.auth.token:
             return httpx.AsyncClient(
-                headers=headers,
+                headers=merged_headers,
                 timeout=timeout or 30,
                 base_url=str(connector.url),
             )
         else:
-            return self._create_client(connector=connector, headers=headers, timeout=timeout)
+            return self._create_client(connector=connector, headers=merged_headers, timeout=timeout)
 
     def _create_client(
         self, *, connector: Connector, headers: dict[str, str] | None = None, timeout: int | None = None

--- a/docs/development/agent-integration/mcp.mdx
+++ b/docs/development/agent-integration/mcp.mdx
@@ -52,7 +52,7 @@ from agentstack_sdk.platform import Connector, ConnectorState
 
 async def main():
     connector = await Connector.create(url="https://api.githubcopilot.com/mcp")
-    connector = await connector.connect(access_token="<your github personal access token goes here>")
+    connector = await connector.connect(headers={"Authorization": "Bearer <your github personal access token goes here>"})
     connector = await connector.wait_for_state(state=ConnectorState.connected)
 
 if __name__ == "__main__":

--- a/docs/development/experimental/connectors.mdx
+++ b/docs/development/experimental/connectors.mdx
@@ -53,9 +53,9 @@ Usual flow works as follows:
 1. **Create**: Client creates a connector by calling `POST /api/v1/connectors` with MCP server URL.
 2. **Connect**: Client initiates connection by calling `POST /api/v1/connectors/{id}/connect`.
    - For OAuth-enabled servers: The response will contain an authorization URL for the user to complete authentication
-   - For token-based authentication: Provide an `access_token` in the connect request body (see [Authentication](#authentication))
+   - For token-based or custom authentication: Provide custom `headers` in the connect request body (see [Authentication](#authentication))
 3. **Authorize** (OAuth only): User visits the authorization URL, authenticates and grants access. Authorization server redirects the user back to the platform with an authorization code.
-4. **Complete**: Platform exchanges the authorization code for access and refresh tokens (OAuth) or stores the provided access token. Once completed, the connector is in `connected` state and ready to be used.
+4. **Complete**: Platform exchanges the authorization code for access and refresh tokens (OAuth) or stores the provided headers. Once completed, the connector is in `connected` state and ready to be used.
 
 ## Authentication
 
@@ -65,20 +65,21 @@ Connectors support two authentication methods:
 
 For MCP servers that support OAuth, the platform handles the full authorization code flow. No additional configuration is needed in the connect request.
 
-### Token-based Authentication
+### Header-based Authentication
 
-For MCP servers that use simple token-based authentication, provide the token when connecting:
+For MCP servers that use token-based or custom authentication, provide headers when connecting:
 
 ```json
 POST /api/v1/connectors/{id}/connect
 {
-  "access_token": "YOUR_API_TOKEN"
+  "headers": {
+    "Authorization": "Bearer YOUR_API_TOKEN",
+    "X-Custom-Header": "value"
+  }
 }
 ```
 
-The authentication token is used differently depending on the connector type:
-- **External HTTP/HTTPS MCP servers**: Token is sent as a Bearer token in the `Authorization` header for all requests
-- **Managed stdio MCP servers**: Token is injected as an environment variable in the container (requires `access_token_env_name` in preset configuration)
+The provided headers are forwarded with all requests to the MCP server. Certain headers are blocked for security reasons, including hop-by-hop headers (`Connection`, `Transfer-Encoding`, etc.), forwarding headers (`Forwarded`, `X-Forwarded-*`, `Via`), `Host`, and cookie headers (`Cookie`, `Set-Cookie`).
 
 ## Error handling
 
@@ -275,12 +276,12 @@ connector = await connector.wait_for_state(
 )
 ```
 
-#### Token-Based Authentication
+#### Header-Based Authentication
 
-For services that use access tokens instead of OAuth:
+For services that use tokens or custom headers instead of OAuth:
 ```python
 connector = await Connector.create(url="https://api.example.com/mcp")
-connector = await connector.connect(access_token="your_api_token")
+connector = await connector.connect(headers={"Authorization": "Bearer your_api_token"})
 connector = await connector.wait_for_state(state=ConnectorState.connected)
 ```
 

--- a/docs/development/reference/changelog.mdx
+++ b/docs/development/reference/changelog.mdx
@@ -1,0 +1,12 @@
+---
+title: "Changelog"
+description: "Breaking changes and notable updates to the Agent Stack API"
+---
+
+All notable breaking changes to the Agent Stack API are documented here. This changelog follows the [Keep a Changelog](https://keepachangelog.com) conventions.
+
+## Unreleased
+
+### Breaking
+
+- **Connectors API**: `POST /api/v1/connectors/{id}/connect` — Replaced the `access_token` field with a `headers` field (a dictionary of arbitrary headers to forward to the MCP server). Certain dangerous headers are blocked. To migrate, change `{"access_token": "<token>"}` to `{"headers": {"Authorization": "Bearer <token>"}}`.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -153,6 +153,7 @@
             "group": "Reference",
             "pages": [
               "development/reference/cli-reference",
+              "development/reference/changelog",
               {
                 "group": "API Reference",
                 "openapi": "development/api-reference/openapi.json"

--- a/tasks.toml
+++ b/tasks.toml
@@ -272,6 +272,12 @@ for pkg in $(fd -t f -g package.json apps agents); do
 done
 yq -i ".providers[].location |= sub(\":(.*)\$\"; \":\" + \"$usage_version\")" agent-registry.yaml
 
+changelog="docs/development/reference/changelog.mdx"
+if [[ -f "$changelog" ]] && grep -q "^## Unreleased" "$changelog"; then
+  today=$(date +%Y-%m-%d)
+  perl -pi -e "s/^## Unreleased\$/## $usage_version ($today)/" "$changelog"
+fi
+
 git add .
 git commit --signoff --no-verify -m "bump: v$usage_version"
 set +x


### PR DESCRIPTION
## Summary
- Replace `access_token` field with `headers` (dict) on `POST /connectors/:id/connect`, allowing arbitrary header forwarding to MCP servers
- Validate and reject dangerous headers (hop-by-hop, forwarding, host, cookie)
- Introduce a changelog page at `docs/development/reference/changelog.mdx` with automatic version stamping during `release:set-version`
- Update Python SDK, TypeScript SDK, and all docs to reflect the new API

## Test plan
- [ ] Run `mise run check` — all checks pass
- [ ] Create a connector, connect with `{"headers": {"Authorization": "Bearer test"}}` and verify headers are forwarded
- [ ] Verify `{"headers": {"Host": "evil.com"}}` returns 422
- [ ] Verify OAuth flow still works (no `headers` provided)