### PR TITLE
Update to python v3.14 in Quickstart

### DIFF
--- a/docs/development/introduction/quickstart.mdx
+++ b/docs/development/introduction/quickstart.mdx
@@ -49,7 +49,7 @@ On Linux, Lima requires QEMU. Install it via these ([instructions](https://www.q
 Open a new terminal and run:
 
 ```bash
-uv python install --quiet --python-preference=only-managed --no-bin 3.13 && uv tool install --refresh --force --python-preference=only-managed --python=3.13 agentstack-cli && agentstack self install
+uv python install --quiet --python-preference=only-managed --no-bin 3.14 && uv tool install --refresh --force --python-preference=only-managed --python=3.14 agentstack-cli && agentstack self install
 ```
 
 Follow the interactive prompts to finish setup and optionally start the VM.
@@ -161,7 +161,7 @@ This will make local agents accessible over the local network, which is needed f
 Run in PowerShell:
 
 ```bash
-uv python install --quiet --python-preference=only-managed --no-bin 3.13; uv tool install --refresh --force --python-preference=only-managed --python=3.13 agentstack-cli; agentstack self install
+uv python install --quiet --python-preference=only-managed --no-bin 3.14; uv tool install --refresh --force --python-preference=only-managed --python=3.14 agentstack-cli; agentstack self install
 ```
 
 Follow the interactive prompts to finish the installation and setup.

--- a/docs/stable/introduction/quickstart.mdx
+++ b/docs/stable/introduction/quickstart.mdx
@@ -49,7 +49,7 @@ On Linux, Lima requires QEMU. Install it via these ([instructions](https://www.q
 Open a new terminal and run:
 
 ```bash
-uv python install --quiet --python-preference=only-managed --no-bin 3.13 && uv tool install --refresh --force --python-preference=only-managed --python=3.13 agentstack-cli && agentstack self install
+uv python install --quiet --python-preference=only-managed --no-bin 3.14 && uv tool install --refresh --force --python-preference=only-managed --python=3.14 agentstack-cli && agentstack self install
 ```
 
 Follow the interactive prompts to finish setup and optionally start the VM.
@@ -161,7 +161,7 @@ This will make local agents accessible over the local network, which is needed f
 Run in PowerShell:
 
 ```bash
-uv python install --quiet --python-preference=only-managed --no-bin 3.13; uv tool install --refresh --force --python-preference=only-managed --python=3.13 agentstack-cli; agentstack self install
+uv python install --quiet --python-preference=only-managed --no-bin 3.14; uv tool install --refresh --force --python-preference=only-managed --python=3.14 agentstack-cli; agentstack self install
 ```
 
 Follow the interactive prompts to finish the installation and setup.


### PR DESCRIPTION
## Summary
When the quickstart is used, it will only install v0.6.3 due to the specified v3.13 of Python. Changing this to Pyhton V3.14 allows v0.7.1 agnetstack to be installed

## Linked Issues
#2495 
<!-- Make sure the linked issue is always provided eg: -->
<!-- Closes #XYZ, Fixes #XYZ, Resolves #XYZ -->


## Documentation
- [x] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.