### PR TITLE
docs(observability): add Future AGI as a supported OTLP backend

### DIFF
--- a/docs/development/agent-integration/observability.mdx
+++ b/docs/development/agent-integration/observability.mdx
@@ -192,10 +192,58 @@ Check your Langfuse project dashboard for incoming traces and metrics.
 
 </Steps>
 
+### Enable Future AGI Observability
+
+[Future AGI](https://futureagi.com) is an open-source e2e agent engineering and optimization platform that helps you ship self-improving AI agents. Its tracer endpoint accepts OpenTelemetry OTLP/HTTP, so you can route Agent Stack traces to it through the same collector config used for Langfuse.
+
+<Steps>
+
+<Step title="Get Future AGI credentials">
+1. Sign up at [app.futureagi.com](https://app.futureagi.com)
+2. From your dashboard, copy your `FI_API_KEY` and `FI_SECRET_KEY`
+</Step>
+
+<Step title="Create a configuration file (config.yaml):">
+```yaml
+collector:
+  exporters:
+    otlphttp/futureagi:
+      endpoint: "https://api.futureagi.com/tracer/v1/traces"
+      headers:
+        x-api-key: "${FI_API_KEY}"
+        x-secret-key: "${FI_SECRET_KEY}"
+  pipelines:
+    traces:
+      receivers: [ otlp ]
+      processors: [ memory_limiter, batch ]
+      exporters: [ otlphttp/futureagi ]
+```
+</Step>
+
+<Step title="Start the platform with the configuration">
+```bash
+FI_API_KEY=your_api_key \
+FI_SECRET_KEY=your_secret_key \
+agentstack platform start -f config.yaml
+```
+</Step>
+
+<Step title="Run and View">
+
+Execute an agent to generate data:
+```sh
+agentstack run chat "Hello"
+```
+Open your project in the [Future AGI dashboard](https://app.futureagi.com) to inspect traces, prompts, completions, and tool execution details.
+</Step>
+
+</Steps>
+
 ## Additional Resources
 
 - **OpenTelemetry Docs**: https://opentelemetry.io/docs/
 - **Langfuse Docs**: https://langfuse.com/docs
 - **Phoenix Docs**: https://docs.arize.com/phoenix
+- **Future AGI Docs**: https://docs.futureagi.com
 - **Prometheus Docs**: https://prometheus.io/docs/
 - **Grafana Docs**: https://grafana.com/docs/

--- a/docs/stable/agent-integration/observability.mdx
+++ b/docs/stable/agent-integration/observability.mdx
@@ -192,10 +192,58 @@ Check your Langfuse project dashboard for incoming traces and metrics.
 
 </Steps>
 
+### Enable Future AGI Observability
+
+[Future AGI](https://futureagi.com) is an open-source e2e agent engineering and optimization platform that helps you ship self-improving AI agents. Its tracer endpoint accepts OpenTelemetry OTLP/HTTP, so you can route Agent Stack traces to it through the same collector config used for Langfuse.
+
+<Steps>
+
+<Step title="Get Future AGI credentials">
+1. Sign up at [app.futureagi.com](https://app.futureagi.com)
+2. From your dashboard, copy your `FI_API_KEY` and `FI_SECRET_KEY`
+</Step>
+
+<Step title="Create a configuration file (config.yaml):">
+```yaml
+collector:
+  exporters:
+    otlphttp/futureagi:
+      endpoint: "https://api.futureagi.com/tracer/v1/traces"
+      headers:
+        x-api-key: "${FI_API_KEY}"
+        x-secret-key: "${FI_SECRET_KEY}"
+  pipelines:
+    traces:
+      receivers: [ otlp ]
+      processors: [ memory_limiter, batch ]
+      exporters: [ otlphttp/futureagi ]
+```
+</Step>
+
+<Step title="Start the platform with the configuration">
+```bash
+FI_API_KEY=your_api_key \
+FI_SECRET_KEY=your_secret_key \
+agentstack platform start -f config.yaml
+```
+</Step>
+
+<Step title="Run and View">
+
+Execute an agent to generate data:
+```sh
+agentstack run chat "Hello"
+```
+Open your project in the [Future AGI dashboard](https://app.futureagi.com) to inspect traces, prompts, completions, and tool execution details.
+</Step>
+
+</Steps>
+
 ## Additional Resources
 
 - **OpenTelemetry Docs**: https://opentelemetry.io/docs/
 - **Langfuse Docs**: https://langfuse.com/docs
 - **Phoenix Docs**: https://docs.arize.com/phoenix
+- **Future AGI Docs**: https://docs.futureagi.com
 - **Prometheus Docs**: https://prometheus.io/docs/
 - **Grafana Docs**: https://grafana.com/docs/


### PR DESCRIPTION
## Summary

Adds an "Enable Future AGI Observability" steps block to both `docs/stable/agent-integration/observability.mdx` and `docs/development/agent-integration/observability.mdx`, mirroring the existing Langfuse section.

[Future AGI](https://futureagi.com) is an open-source e2e agent engineering and optimization platform that helps you ship self-improving AI agents. It exposes an OTLP/HTTP tracer endpoint at `https://api.futureagi.com/tracer/v1/traces` using `x-api-key` / `x-secret-key` auth, so it slots into the Agent Stack collector config without any code changes on the agent side.

Also adds a Future AGI Docs link under "Additional Resources".

## What changed

- New `### Enable Future AGI Observability` block with credentials, collector `config.yaml` snippet, and `agentstack platform start -f config.yaml` instructions.
- Same change applied to both stable and development versions of the page so they stay in sync.
- One new bullet in "Additional Resources".

## Smoke test

Verified end-to-end against the published Future AGI tracer endpoint:

- `POST https://api.futureagi.com/tracer/v1/traces` with `x-api-key` + `x-secret-key` headers → `HTTP 200 OK`, request-id returned.
- A test span with `project_name` resource attribute landed in the Future AGI dashboard under the named project.

## Test plan

- [ ] `mintlify broken-links` passes (verified locally — no broken links found)
- [ ] `mintlify dev` boots without MDX errors (verified locally — preview ready, both pages render at 200 with the new section)
- [ ] Maintainer review of the wording and YAML config style (env-var `${FI_API_KEY}` vs the literal `<auth-string>` placeholder used in the Langfuse block — happy to switch to literal for stylistic consistency if preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)